### PR TITLE
Refactory33 budget creation to appstate

### DIFF
--- a/MoneyMoa/App/AppState.swift
+++ b/MoneyMoa/App/AppState.swift
@@ -15,45 +15,98 @@ import Observation
 final class AppState {
     var isLoading = true
     var loadingMessage = "데이터를 준비하고 있습니다..."
-    
+
     private let diContainer: DIContainer
     private var initializationTask: Task<Void, Never>?
-    
+
     init(diContainer: DIContainer) {
         self.diContainer = diContainer
     }
-    
+
     func initializeApp() async {
         // 이미 초기화가 진행 중이면 해당 태스크를 기다림
         if let existingTask = initializationTask {
             await existingTask.value
             return
         }
-        
+
         // 새로운 초기화 태스크 생성
         let task = Task { @MainActor in
             isLoading = true
             loadingMessage = "추천 카테고리를 설정하고 있습니다..."
-            
-            do {
-                let hasInitialized = UserDefaults.standard.bool(forKey: "hasInitializedCategories")
-                
-                if !hasInitialized {
-                    let importUseCase = diContainer.makeImportRecommendedCategoriesUseCase()
-                    try await importUseCase.execute()
-                    #if !DEBUG
-                    UserDefaults.standard.set(true, forKey: "hasInitializedCategories")
-                    #endif
-                }
-            } catch {
-                print("추천 카테고리 초기화 실패: \(error)")
-            }
-            
+
+            await checkInitialCategories()
+            await checkCurrentMonthBudget()
+
             isLoading = false
             initializationTask = nil
         }
-        
+
         initializationTask = task
         await task.value
+    }
+
+    private func checkInitialCategories() async {
+        loadingMessage = "추천 카테고리를 설정하고 있습니다..."
+
+        let hasInitialized = UserDefaults.standard.bool(
+            forKey: "hasInitializedCategories"
+        )
+
+        if !hasInitialized {
+            do {
+                let importUseCase =
+                    diContainer.makeImportRecommendedCategoriesUseCase()
+                try await importUseCase.execute()
+                #if !DEBUG
+                    UserDefaults.standard.set(
+                        true,
+                        forKey: "hasInitializedCategories"
+                    )
+                #endif
+            } catch {
+                print("error")
+            }
+        }
+    }
+
+    private func checkCurrentMonthBudget() async {
+        loadingMessage = "예산을 확인하고 있습니다..."
+
+        do {
+            let currentYearMonth = YearMonth.current
+            let getBudgetUseCase = diContainer.makeGetMonthlyBudgetUseCase()
+
+            // 현재 월 예산 확인
+            let existingBudget = try await getBudgetUseCase.execute(
+                yearMonth: currentYearMonth
+            )
+
+            // 예산이 이미 있으면 종료
+            guard existingBudget == nil else { return }
+
+            // 템플릿 확인
+            let getBudgetTemplateUseCase =
+                diContainer.makeGetBudgetTemplateUseCase()
+            guard let templateDTO = try await getBudgetTemplateUseCase.execute()
+            else {
+                print("예산 템플릿이 없습니다.")
+                return
+            }
+
+            // 템플릿으로 현재 월 예산 생성
+            loadingMessage = "이번 달 예산을 생성하고 있습니다..."
+            let createBudgetUseCase =
+                diContainer.makeCreateBudgetFromTemplateUseCase()
+            try await createBudgetUseCase.execute(
+                template: templateDTO,
+                yearMonth: currentYearMonth
+            )
+
+            print("현재 월 예산이 템플릿으로부터 생성되었습니다.")
+        } catch {
+            print("예산 확인/생성 실패: \(error)")
+            // 예산 생성 실패해도 앱은 계속 진행
+        }
     }
 }

--- a/MoneyMoa/Domain/DI/DIContainer.swift
+++ b/MoneyMoa/Domain/DI/DIContainer.swift
@@ -157,8 +157,6 @@ extension DIContainer {
             getMonthlyTransactionsUseCase: makeGetMonthlyTransactionsUseCase(),
             getExpenseSumUntilDateUseCase: makeGetExpenseSumUntilDateUseCase(),
             getMonthlyBudgetUseCase: makeGetMonthlyBudgetUseCase(),
-            getBudgetTemplateUseCase: makeGetBudgetTemplateUseCase(),
-            createBudgetFromTemplateUseCase: makeCreateBudgetFromTemplateUseCase(),
             transactionEventPublisher: makeTransactionEventPublisher()
         )
     }

--- a/MoneyMoa/Domain/UseCases/Budget/CreateBudgetFromTemplateUseCase/CreateBudgetFromTemplateUseCase.swift
+++ b/MoneyMoa/Domain/UseCases/Budget/CreateBudgetFromTemplateUseCase/CreateBudgetFromTemplateUseCase.swift
@@ -32,5 +32,6 @@ public protocol CreateBudgetFromTemplateUseCase {
     ///       yearMonth: YearMonth(year: 2024, month: 8)
     ///   )
     ///   ```
+    @discardableResult
     func execute(template: BudgetTemplateDTO, yearMonth: YearMonth) async throws -> BudgetDTO
 }

--- a/MoneyMoa/Presentation/Main/ViewModels/MainViewModel.swift
+++ b/MoneyMoa/Presentation/Main/ViewModels/MainViewModel.swift
@@ -54,8 +54,6 @@ public class MainViewModel {
     private let getMonthlyTransactionsUseCase: GetMonthlyTransactionsUseCase
     private let getExpenseSumUntilDateUseCase: GetExpenseSumUntilDateUseCase
     private let getMonthlyBudgetUseCase: GetMonthlyBudgetUseCase
-    private let getBudgetTemplateUseCase: GetBudgetTemplateUseCase
-    private let createBudgetFromTemplateUseCase: CreateBudgetFromTemplateUseCase
     private let transactionEventPublisher: TransactionEventPublisher
     
     // MARK: - Publisher Subscriptions
@@ -69,16 +67,12 @@ public class MainViewModel {
         getMonthlyTransactionsUseCase: GetMonthlyTransactionsUseCase,
         getExpenseSumUntilDateUseCase: GetExpenseSumUntilDateUseCase,
         getMonthlyBudgetUseCase: GetMonthlyBudgetUseCase,
-        getBudgetTemplateUseCase: GetBudgetTemplateUseCase,
-        createBudgetFromTemplateUseCase: CreateBudgetFromTemplateUseCase,
         transactionEventPublisher: TransactionEventPublisher,
         initialYearMonth: YearMonth = YearMonth.current
     ) {
         self.getMonthlyTransactionsUseCase = getMonthlyTransactionsUseCase
         self.getExpenseSumUntilDateUseCase = getExpenseSumUntilDateUseCase
         self.getMonthlyBudgetUseCase = getMonthlyBudgetUseCase
-        self.getBudgetTemplateUseCase = getBudgetTemplateUseCase
-        self.createBudgetFromTemplateUseCase = createBudgetFromTemplateUseCase
         self.transactionEventPublisher = transactionEventPublisher
         self.currentYearMonth = initialYearMonth
         
@@ -92,9 +86,7 @@ public class MainViewModel {
         case calculateCurrentMonthExpense
         case loadPreviousMonthExpense
         case loadCurrentMonthBudget
-        case checkBudgetTemplate
-        case createBudgetFromTemplate(BudgetTemplateDTO)
-        case setBudget(BudgetDTO)
+        case setBudget(BudgetDTO?)
         case updateSummaryData
         case handleYearMonth(HandleYearMonth)
     }
@@ -128,16 +120,6 @@ public class MainViewModel {
         case .loadCurrentMonthBudget:
             Task {
                 let action = await loadCurrentMonthBudget()
-                send(action)
-            }
-        case .checkBudgetTemplate:
-            Task {
-                let action = await checkBudgetTemplate()
-                send(action)
-            }
-        case .createBudgetFromTemplate(let template):
-            Task {
-                let action = await createBudgetFromTemplate(template)
                 send(action)
             }
         case .setBudget(let budget):
@@ -271,59 +253,15 @@ public class MainViewModel {
         
         do {
             let budgetDTO = try await getMonthlyBudgetUseCase.execute(yearMonth: currentYearMonth)
-            if let budgetDTO {
-                return .setBudget(budgetDTO)
-            } else {
-                return .checkBudgetTemplate
-            }
+            return .setBudget(budgetDTO)
         } catch {
             print("Current month budget load error: \(error.localizedDescription)")
-            return .checkBudgetTemplate
-        }
-    }
-    
-    /// 예산 템플릿이 있는지 확인합니다
-    private func checkBudgetTemplate() async -> Action {
-        startSummaryLoading()
-        defer {
-            stopSummaryLoading()
-        }
-        
-        do {
-            if let budgetTemplate = try await getBudgetTemplateUseCase.execute() {
-                return .createBudgetFromTemplate(budgetTemplate)
-            } else {
-                currentMonthBudget = nil
-                return .updateSummaryData
-            }
-        } catch {
-            print("Budget template check error: \(error.localizedDescription)")
-            currentMonthBudget = nil
-            return .updateSummaryData
-        }
-    }
-    
-    /// 템플릿을 기반으로 예산을 생성합니다
-    private func createBudgetFromTemplate(_ template: BudgetTemplateDTO) async -> Action {
-        startSummaryLoading()
-        defer {
-            stopSummaryLoading()
-        }
-        
-        do {
-            let newBudget = try await createBudgetFromTemplateUseCase.execute(
-                template: template,
-                yearMonth: currentYearMonth
-            )
-            return .setBudget(newBudget)
-        } catch {
-            currentMonthBudget = nil
-            return .updateSummaryData
+            return .setBudget(nil)
         }
     }
     
     /// 예산을 설정합니다 (reload 대신 직접 설정)
-    private func setBudget(_ budget: BudgetDTO) {
+    private func setBudget(_ budget: BudgetDTO?) {
         currentMonthBudget = budget
     }
     

--- a/MoneyMoaTests/App/AppStateTests.swift
+++ b/MoneyMoaTests/App/AppStateTests.swift
@@ -42,7 +42,7 @@ final class AppStateTests: XCTestCase {
     
     // MARK: - First Launch Tests
     
-    func testInitializeApp_OnFirstLaunch_ShouldExecuteImportUseCase() async {
+    func testInitializeApp_OnFirstLaunch_ShouldImportCategories() async {
         // Given
         setHasInitialized(false)
         
@@ -51,33 +51,7 @@ final class AppStateTests: XCTestCase {
         
         // Then
         XCTAssertFalse(appState.isLoading, "초기화 완료 후 로딩이 끝나야 합니다")
-    }
-    
-    func testInitializeApp_OnFirstLaunch_ShouldUpdateLoadingMessage() async {
-        // Given
-        setHasInitialized(false)
-        
-        var loadingMessages: [String] = []
-        
-        // 로딩 메시지 변화 관찰
-        let expectation = XCTestExpectation(description: "로딩 메시지 업데이트")
-        
-        Task {
-            // 초기 메시지 기록
-            loadingMessages.append(appState.loadingMessage)
-            
-            await appState.initializeApp()
-            
-            // 완료 후 메시지 기록
-            loadingMessages.append(appState.loadingMessage)
-            expectation.fulfill()
-        }
-        
-        // When
-        await fulfillment(of: [expectation], timeout: 5.0)
-        
-        // Then
-        XCTAssertTrue(loadingMessages.contains("추천 카테고리를 설정하고 있습니다..."), "로딩 메시지가 업데이트되어야 합니다")
+        // Note: 실제 카테고리 import는 MockCategoryRepository를 통해 검증 가능
     }
     
     // MARK: - Subsequent Launch Tests
@@ -95,25 +69,16 @@ final class AppStateTests: XCTestCase {
     
     // MARK: - Error Handling Tests
     
-    func testInitializeApp_WhenImportUseCaseFails_ShouldStillCompleteLoading() async {
+    func testInitializeApp_WhenErrorOccurs_ShouldStillCompleteLoading() async {
         // Given
         setHasInitialized(false)
+        // Mock에서 에러가 발생해도 앱이 계속 진행되어야 함
         
         // When
         await appState.initializeApp()
         
         // Then
         XCTAssertFalse(appState.isLoading, "에러가 발생해도 로딩이 완료되어야 합니다")
-    }
-    
-    func testInitializeApp_WhenImportUseCaseFails_ShouldNotCrashApp() async {
-        // Given
-        setHasInitialized(false)
-        
-        // When & Then (에러가 발생해도 크래시하지 않아야 함)
-        await appState.initializeApp()
-        
-        XCTAssertFalse(appState.isLoading, "에러 상황에서도 앱이 계속 진행되어야 합니다")
     }
     
     // MARK: - Loading State Management Tests
@@ -166,6 +131,138 @@ final class AppStateTests: XCTestCase {
         
         // Then
         XCTAssertFalse(appState.isLoading, "모든 초기화가 완료되어야 합니다")
+    }
+    
+    // MARK: - Budget Tests
+    
+    func testInitializeApp_WhenNoBudgetAndNoTemplate_ShouldCompleteWithoutError() async {
+        // Given
+        setHasInitialized(true) // Skip category initialization
+        // MockBudgetRepository는 기본적으로 empty scenario
+        
+        // When
+        await appState.initializeApp()
+        
+        // Then
+        XCTAssertFalse(appState.isLoading, "템플릿이 없어도 초기화가 완료되어야 합니다")
+    }
+    
+    func testInitializeApp_BudgetCreationFailure_ShouldStillCompleteLoading() async {
+        // Given
+        setHasInitialized(true) // Skip category initialization
+        // Template 설정하되, repository에서 에러 발생하도록 설정
+        mockDIContainer.mockBudgetRepository.shouldFail = true
+        let template = TestDataFactory.createBudgetTemplate()
+        mockDIContainer.mockBudgetTemplateRepository.setTemplate(template)
+        
+        // When
+        await appState.initializeApp()
+        
+        // Then
+        XCTAssertFalse(appState.isLoading, "에러가 발생해도 로딩이 완료되어야 합니다")
+    }
+    
+    // MARK: - Repository Interaction Tests
+    
+    func testInitializeApp_WhenTemplateExists_ShouldCallCreateBudgetFromTemplate() async {
+        // Given
+        setHasInitialized(true)
+        let template = TestDataFactory.createBudgetTemplate(
+            totalAmount: 1500000,
+            categoryBudgetTemplates: []
+        )
+        mockDIContainer.mockBudgetTemplateRepository.setTemplate(template)
+        
+        // When
+        await appState.initializeApp()
+        
+        // Then
+        // Repository에 예산이 생성되었는지 확인
+        let hasCurrentBudget = mockDIContainer.mockBudgetRepository.hasBudget(for: YearMonth.current)
+        XCTAssertTrue(hasCurrentBudget, "템플릿으로부터 현재 월 예산이 생성되어야 합니다")
+    }
+    
+    func testInitializeApp_WhenBudgetExists_ShouldNotCallCreateBudget() async {
+        // Given
+        setHasInitialized(true)
+        let existingBudget = TestDataFactory.createBudget(
+            month: YearMonth.current,
+            totalAmount: 2000000
+        )
+        mockDIContainer.mockBudgetRepository.setBudgets([existingBudget])
+        
+        // Template이 있어도 사용하지 않아야 함
+        let template = TestDataFactory.createBudgetTemplate(totalAmount: 3000000)
+        mockDIContainer.mockBudgetTemplateRepository.setTemplate(template)
+        
+        // When
+        await appState.initializeApp()
+        
+        // Then
+        // Repository에 추가 예산이 생성되지 않았는지 확인  
+        let hasCurrentBudget = mockDIContainer.mockBudgetRepository.hasBudget(for: YearMonth.current)
+        XCTAssertTrue(hasCurrentBudget, "기존 예산이 유지되어야 합니다")
+        XCTAssertEqual(mockDIContainer.mockBudgetRepository.budgetCount, 1, "예산이 중복 생성되지 않아야 합니다")
+    }
+    
+    // MARK: - Integration Tests
+    
+    func testFullInitialization_FirstLaunch_WithTemplate() async {
+        // Given: 첫 실행, 카테고리 초기화 필요, 템플릿 있음
+        setHasInitialized(false)
+        let template = TestDataFactory.createBudgetTemplate(
+            totalAmount: 3000000,
+            categoryBudgetTemplates: [
+                TestDataFactory.createCategoryBudgetTemplate(
+                    amount: 1000000,
+                    categoryID: UUID(),
+                    categoryName: "식비",
+                    budgetTemplateId: UUID()
+                ),
+                TestDataFactory.createCategoryBudgetTemplate(
+                    amount: 500000,
+                    categoryID: UUID(),
+                    categoryName: "교통비",
+                    budgetTemplateId: UUID()
+                )
+            ]
+        )
+        mockDIContainer.mockBudgetTemplateRepository.setTemplate(template)
+        
+        // When
+        await appState.initializeApp()
+        
+        // Then
+        XCTAssertFalse(appState.isLoading, "초기화가 완료되어야 합니다")
+        
+        // 카테고리 초기화 확인
+        #if !DEBUG
+        XCTAssertTrue(
+            UserDefaults.standard.bool(forKey: "hasInitializedCategories"),
+            "카테고리가 초기화되어야 합니다"
+        )
+        #endif
+        
+        // 예산 생성 확인
+        let hasCurrentBudget = mockDIContainer.mockBudgetRepository.hasBudget(for: YearMonth.current)
+        XCTAssertTrue(hasCurrentBudget, "현재 월 예산이 생성되어야 합니다")
+        XCTAssertEqual(mockDIContainer.mockBudgetRepository.budgetCount, 1, "예산이 하나만 생성되어야 합니다")
+    }
+
+    func testFullInitialization_FirstLaunch_NoTemplate() async {
+        // Given: 첫 실행, 템플릿 없음
+        setHasInitialized(false)
+        // No template set
+        
+        // When
+        await appState.initializeApp()
+        
+        // Then
+        XCTAssertFalse(appState.isLoading, "초기화가 완료되어야 합니다")
+        
+        // 예산이 생성되지 않았는지 확인
+        let hasCurrentBudget = mockDIContainer.mockBudgetRepository.hasBudget(for: YearMonth.current)
+        XCTAssertFalse(hasCurrentBudget, "템플릿이 없으면 예산이 생성되지 않아야 합니다")
     }
     
     // MARK: - Helper Methods

--- a/MoneyMoaTests/Presentation/Main/MainViewModelTests.swift
+++ b/MoneyMoaTests/Presentation/Main/MainViewModelTests.swift
@@ -33,8 +33,6 @@ final class MainViewModelTests: XCTestCase {
             getMonthlyTransactionsUseCase: mockDIContainer.makeGetMonthlyTransactionsUseCase(),
             getExpenseSumUntilDateUseCase: mockDIContainer.makeGetExpenseSumUntilDateUseCase(),
             getMonthlyBudgetUseCase: mockDIContainer.makeGetMonthlyBudgetUseCase(),
-            getBudgetTemplateUseCase: mockDIContainer.makeGetBudgetTemplateUseCase(),
-            createBudgetFromTemplateUseCase: mockDIContainer.makeCreateBudgetFromTemplateUseCase(),
             transactionEventPublisher: mockTransactionEventPublisher
         )
         
@@ -114,8 +112,6 @@ final class MainViewModelTests: XCTestCase {
             getMonthlyTransactionsUseCase: mockDIContainer.makeGetMonthlyTransactionsUseCase(),
             getExpenseSumUntilDateUseCase: mockDIContainer.makeGetExpenseSumUntilDateUseCase(),
             getMonthlyBudgetUseCase: mockDIContainer.makeGetMonthlyBudgetUseCase(),
-            getBudgetTemplateUseCase: mockDIContainer.makeGetBudgetTemplateUseCase(),
-            createBudgetFromTemplateUseCase: mockDIContainer.makeCreateBudgetFromTemplateUseCase(),
             transactionEventPublisher: mockTransactionEventPublisher,
             initialYearMonth: customYearMonth
         )
@@ -131,7 +127,7 @@ final class MainViewModelTests: XCTestCase {
         viewModel.send(.loadTransactions)
         
         // Wait for async operations
-        try? await Task.sleep(nanoseconds: 1_000_000_000) // 1초
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1초
         
         // Then
         XCTAssertFalse(viewModel.transactionsByDate.isEmpty)
@@ -173,22 +169,106 @@ final class MainViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentYearMonth, targetYearMonth)
     }
     
-    // MARK: - Test Methods - Budget Template Integration
+    // MARK: - Test Methods - Budget Loading Scenarios
     
-    func test_budgetTemplateFlow_withoutTemplate_showsNoBudgetState() async {
-        // Given - No budget template exists (MockDIContainer handles this)
+    func test_loadCurrentMonthBudget_withBudgetExists_setsBudget() async {
+        // Given - Setup budget in mock repository
+        let currentMonth = YearMonth.current
+        let testBudget = BudgetDTO(
+            id: UUID(),
+            month: currentMonth,
+            totalAmount: 1000000,
+            categoryBudgets: []
+        )
+        mockDIContainer.mockBudgetRepository.addBudget(testBudget)
         
         // When
         viewModel.send(.loadTransactions)
         
         // Wait for all async operations
-        try? await Task.sleep(nanoseconds: 1_000_000_000) // 1초
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1초
         
         // Then
         XCTAssertNotNil(viewModel.summaryData)
-        // MockDIContainer returns mock budget data, so we verify the loading completed
+        XCTAssertNotNil(viewModel.summaryData?.budget)
+        XCTAssertEqual(viewModel.summaryData?.budget?.totalAmount, 1000000)
+        XCTAssertFalse(viewModel.isSummaryLoading)
+    }
+    
+    func test_loadCurrentMonthBudget_withNoBudget_setsNil() async {
+        // Given - No budget exists (MockDIContainer empty scenario)
+        mockDIContainer.mockBudgetRepository.clearData()
+        
+        // When
+        viewModel.send(.loadTransactions)
+        
+        // Wait for all async operations
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1초
+        
+        // Then
+        XCTAssertNotNil(viewModel.summaryData)
+        XCTAssertNil(viewModel.summaryData?.budget)
         XCTAssertFalse(viewModel.isSummaryLoading)
         XCTAssertTrue(viewModel.hasSummaryData)
+    }
+    
+    func test_setBudget_withValidBudget_updatesSummary() async {
+        // Given
+        let testBudget = BudgetDTO(
+            id: UUID(),
+            month: YearMonth.current,
+            totalAmount: 500000,
+            categoryBudgets: []
+        )
+        
+        // Setup transactions first
+        viewModel.send(.loadTransactions)
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초
+        
+        // When
+        viewModel.send(.setBudget(testBudget))
+        
+        // Wait for summary update
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초
+        
+        // Then
+        XCTAssertNotNil(viewModel.summaryData)
+        XCTAssertNotNil(viewModel.summaryData?.budget)
+        XCTAssertEqual(viewModel.summaryData?.budget?.totalAmount, 500000)
+    }
+    
+    func test_setBudget_withNilBudget_updatesSummary() async {
+        // Given - Load transactions first
+        viewModel.send(.loadTransactions)
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초
+        
+        // When
+        viewModel.send(.setBudget(nil))
+        
+        // Wait for summary update
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초
+        
+        // Then
+        XCTAssertNotNil(viewModel.summaryData)
+        XCTAssertNil(viewModel.summaryData?.budget)
+        XCTAssertNil(viewModel.summaryData?.remainingBudget)
+        XCTAssertNil(viewModel.summaryData?.budgetUsagePercentage)
+    }
+    
+    func test_budgetLoading_withRepositoryError_handlesGracefully() async {
+        // Given - Configure budget repository to fail
+        mockDIContainer.mockBudgetRepository.shouldFail = true
+        
+        // When
+        viewModel.send(.loadTransactions)
+        
+        // Wait for all async operations
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1초
+        
+        // Then - Should still complete with nil budget
+        XCTAssertNotNil(viewModel.summaryData)
+        XCTAssertNil(viewModel.summaryData?.budget)
+        XCTAssertFalse(viewModel.isSummaryLoading)
     }
     
     // MARK: - Test Methods - Computed Properties
@@ -198,7 +278,7 @@ final class MainViewModelTests: XCTestCase {
         viewModel.send(.loadTransactions)
         
         // Wait for async loading
-        try? await Task.sleep(nanoseconds: 1_000_000_000) // 1초
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1초
         
         // Then
         // Test data has 40,000 (15,000 + 25,000) in expenses for current month
@@ -210,7 +290,7 @@ final class MainViewModelTests: XCTestCase {
         viewModel.send(.loadTransactions)
         
         // Wait for async loading
-        try? await Task.sleep(nanoseconds: 1_000_000_000) // 1초
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1초
         
         // Then  
         // Test data has 100,000 in income for current month
@@ -225,63 +305,47 @@ final class MainViewModelTests: XCTestCase {
         viewModel.send(.loadTransactions)
         
         // Wait for async operations
-        try? await Task.sleep(nanoseconds: 1_000_000_000) // 1초
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1초
         
         // Then
         XCTAssertTrue(viewModel.hasSummaryData)
     }
     
-    // MARK: - Test Methods - Repository-based Testing
+    // MARK: - Test Methods - Basic Error Handling
     
-    func test_loadTransactions_withRepositoryData_loadsCorrectly() async throws {
-        // Given - Repository has test data
-        let mockRepository = mockDIContainer.mockTransactionRepository
-        XCTAssertFalse(mockRepository.shouldFail)
-        
-        // When
-        viewModel.send(.loadTransactions)
-        
-        // Wait for async operations
-        try? await Task.sleep(nanoseconds: 1_000_000_000) // 1초
-        
-        // Then
-        XCTAssertFalse(viewModel.isLoading)
-        XCTAssertFalse(viewModel.isSummaryLoading)
-        XCTAssertNotNil(viewModel.summaryData)
-    }
-    
-    func test_loadTransactions_withRepositoryFailure_handlesErrorGracefully() async throws {
+    func test_loadTransactions_withRepositoryFailure_handlesErrorGracefully() async {
         // Given - Repository configured to fail
-        let mockRepository = mockDIContainer.mockTransactionRepository
-        mockRepository.shouldFail = true
+        mockDIContainer.mockTransactionRepository.shouldFail = true
         
         // When
         viewModel.send(.loadTransactions)
         
         // Wait for async operations
-        try? await Task.sleep(nanoseconds: 1_000_000_000) // 1초
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1초
         
         // Then - ViewModel should handle error gracefully
         XCTAssertFalse(viewModel.isLoading)
-        // Depending on error handling implementation, summary might still complete
+        // Should still complete summary flow
+        XCTAssertNotNil(viewModel.summaryData)
     }
     
     // MARK: - Test Methods - Event Publisher Integration
     
-    func test_transactionEventPublisher_receivesEvents() async {
+    func test_transactionEventPublisher_receivesCurrentMonthEvents() async {
         // Given
         viewModel.send(.loadTransactions)
-        try? await Task.sleep(nanoseconds: 500_000_000) // 0.5초
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초
         
-        // When - Simulate transaction event
+        // When - Simulate transaction event for current month
         let event = TransactionEvent(type: .created, yearMonth: YearMonth.current)
         mockTransactionEventPublisher.publish(event)
         
         // Wait for event processing
-        try? await Task.sleep(nanoseconds: 500_000_000) // 0.5초
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초
         
         // Then - Should trigger data reload
         XCTAssertEqual(mockTransactionEventPublisher.publishedEvents.count, 1)
         XCTAssertEqual(mockTransactionEventPublisher.publishedEvents.first?.type, .created)
     }
+    
 }

--- a/MoneyMoaTests/Presentation/Navigation/MainViewNavigationTests.swift
+++ b/MoneyMoaTests/Presentation/Navigation/MainViewNavigationTests.swift
@@ -25,8 +25,6 @@ final class MainViewNavigationTests: XCTestCase {
             getMonthlyTransactionsUseCase: mockContainer.makeGetMonthlyTransactionsUseCase(),
             getExpenseSumUntilDateUseCase: mockContainer.makeGetExpenseSumUntilDateUseCase(),
             getMonthlyBudgetUseCase: mockContainer.makeGetMonthlyBudgetUseCase(),
-            getBudgetTemplateUseCase: mockContainer.makeGetBudgetTemplateUseCase(),
-            createBudgetFromTemplateUseCase: mockContainer.makeCreateBudgetFromTemplateUseCase(),
             transactionEventPublisher: mockContainer.makeTransactionEventPublisher()
         )
         
@@ -45,7 +43,7 @@ final class MainViewNavigationTests: XCTestCase {
         let transaction = TransactionDTO.mockStandardExpense
         
         // When
-        testHandleTransactionTap(transaction)
+        handleTransactionTap(transaction)
         
         // Then
         XCTAssertEqual(mockRouter.pushCallCount, 1)
@@ -54,7 +52,7 @@ final class MainViewNavigationTests: XCTestCase {
     
     func testHandleChartTap_CallsRouterPush() {
         // When
-        testHandleChartTap()
+        handleChartTap()
         
         // Then
         XCTAssertEqual(mockRouter.pushCallCount, 1)
@@ -63,7 +61,7 @@ final class MainViewNavigationTests: XCTestCase {
     
     func testHandleSettingsTap_CallsRouterPush() {
         // When
-        testHandleSettingsTap()
+        handleSettingsTap()
         
         // Then
         XCTAssertEqual(mockRouter.pushCallCount, 1)
@@ -72,7 +70,7 @@ final class MainViewNavigationTests: XCTestCase {
     
     func testHandleBudgetSetupTap_CallsRouterPush() {
         // When
-        testHandleBudgetSetupTap()
+        handleBudgetSetupTap()
         
         // Then
         XCTAssertEqual(mockRouter.pushCallCount, 1)
@@ -81,7 +79,7 @@ final class MainViewNavigationTests: XCTestCase {
     
     func testHandleAddTransactionTap_CallsRouterPresent() {
         // When
-        testHandleAddTransactionTap()
+        handleAddTransactionTap()
         
         // Then
         XCTAssertEqual(mockRouter.presentCallCount, 1)
@@ -96,7 +94,7 @@ final class MainViewNavigationTests: XCTestCase {
         let expectedTransaction = TransactionDTO.mockLunch
         
         // When
-        testHandleTransactionTap(expectedTransaction)
+        handleTransactionTap(expectedTransaction)
         
         // Then
         if case .transactions(.detail(let passedTransaction)) = mockRouter.lastPushedRoute {
@@ -115,10 +113,10 @@ final class MainViewNavigationTests: XCTestCase {
         let transaction = TransactionDTO.mockTransport
         
         // When
-        testHandleChartTap()
-        testHandleSettingsTap()
-        testHandleTransactionTap(transaction)
-        testHandleAddTransactionTap()
+        handleChartTap()
+        handleSettingsTap()
+        handleTransactionTap(transaction)
+        handleAddTransactionTap()
         
         // Then
         XCTAssertEqual(mockRouter.pushCallCount, 3) // chart, settings, transaction
@@ -130,9 +128,9 @@ final class MainViewNavigationTests: XCTestCase {
         let transaction = TransactionDTO.mockBeauty
         
         // When
-        testHandleChartTap()
-        testHandleTransactionTap(transaction)
-        testHandleSettingsTap()
+        handleChartTap()
+        handleTransactionTap(transaction)
+        handleSettingsTap()
         
         // Then
         let expectedRoutes: [AppRoute] = [
@@ -165,7 +163,7 @@ final class MainViewNavigationTests: XCTestCase {
         let action = MainViewModel.HandleYearMonth.moveToNextMonth
         
         // When & Then
-        XCTAssertNoThrow(testHandleYearMonthChange(action))
+        XCTAssertNoThrow(handleYearMonthChange(action))
         
         // This method calls viewModel.send(), which is internal logic
         // We verify it doesn't crash and doesn't affect router
@@ -178,30 +176,30 @@ final class MainViewNavigationTests: XCTestCase {
 
 private extension MainViewNavigationTests {
     
-    // Test methods that simulate MainView navigation handlers
-    func testHandleTransactionTap(_ transaction: TransactionDTO) {
+    // Actual MainView navigation handlers that should be tested
+    func handleTransactionTap(_ transaction: TransactionDTO) {
         mockRouter.push(.transactions(.detail(transaction)))
     }
     
-    func testHandleChartTap() {
+    func handleChartTap() {
         mockRouter.push(.statistics(.overview))
     }
     
-    func testHandleSettingsTap() {
+    func handleSettingsTap() {
         mockRouter.push(.settings(.root))
     }
     
-    func testHandleBudgetSetupTap() {
+    func handleBudgetSetupTap() {
         mockRouter.push(.settings(.budget(YearMonth.current)))
     }
     
-    func testHandleAddTransactionTap() {
+    func handleAddTransactionTap() {
         mockRouter.present(.transactions(.add), as: .sheet)
     }
     
-    func testHandleYearMonthChange(_ action: MainViewModel.HandleYearMonth) {
-        // This would normally call viewModel.send(.handleYearMonth(action))
-        // For testing purposes, we just verify it doesn't crash
+    func handleYearMonthChange(_ action: MainViewModel.HandleYearMonth) {
+        // This would call actual MainView logic
+        mainViewModel.send(.handleYearMonth(action))
     }
     
 }


### PR DESCRIPTION
## 개요
MainView 에서 onAppear와 YearMonth 에 따라 Budget을 조회하고, BudgetTemplate를 조회하고 생성하는 로직은 App 시작시 한번 이루어지면 된다고 판단하여 분리

## KeyChanges
  - AppState 초기화시 현재월 예산만 확인/생성하도록 로직 추가
  - 기존 Category 확인 로직 함수로 분리
  - AppStateTests 개선 및 중복 테스트 제거 (18개 → 13개)
  - MainViewModel에서 불필요한 BudgetTemplate 관련 의존성 제거
  - AppState로 이동된 BudgetTemplate 로직에 맞춰 Budget 조회만 담당하도록 단순화
  - MainViewModelTests 리팩토
  - MainViewNavigationTests의 불필요한 Test Helpers 정리