### PR TITLE
refactor: CategoryFormView Padding 조절

### DIFF
--- a/MoneyMoa/Presentation/Category/NewCategoryForm/CategoryFormView.swift
+++ b/MoneyMoa/Presentation/Category/NewCategoryForm/CategoryFormView.swift
@@ -20,24 +20,24 @@ struct CategoryFormView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 24) {
                 TransactionTypeSelectionView(selectedTransactionType: $viewModel.selectedTransactionType)
+                    .padding(4)
+                    .clipped(antialiased: false)
 
                 categoryNameSection
 
-                if viewModel.mode == .selection {
+                if viewModel.selectedCategory == nil {
                     subCategoryNameSection
                 }
 
                 IconSelectionView(color: viewModel.selectedTransactionType.color, selectedIcon: $viewModel.categoryIconName)
 
-                if viewModel.mode == .configuration {
+                if viewModel.selectedCategory != nil {
                     subCategoriesSection
                 }
             }
         }
+        .padding(.horizontal, 16)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-//                Button("취소") { dismiss() }
-            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("저장") {
                     viewModel.send(.tappedSubmitButton(router))


### PR DESCRIPTION
- Router 로 present 할 때 부모View에 기본 padding 이 없어서 padding 추가
- TransactionTypeSelectionView에 padding 추가 및 clipped(antialiased: false) 추가
- SubCateogry 관련 버튼, Textfield 조건을 viewModel.mode 가 아닌 selectedCategory 로 변경 (add 냐, update냐로 변경)