### PR TITLE
Feature/66 delete category subcategory

### DIFF
--- a/MoneyMoa/App/DI/AppDIContainer.swift
+++ b/MoneyMoa/App/DI/AppDIContainer.swift
@@ -181,6 +181,18 @@ final class AppDIContainer: DIContainer {
         return UpdateSubCategoryUseCaseImpl(categoryRepository: repository)
     }
 
+    /// Production DeleteCategoryUseCase를 생성합니다
+    func makeDeleteCategoryUseCase() -> DeleteCategoryUseCase {
+        let repository = makeCategoryRepository()
+        return DeleteCategoryUseCaseImpl(categoryRepository: repository)
+    }
+
+    /// Production DeleteSubCategoryUseCase를 생성합니다
+    func makeDeleteSubCategoryUseCase() -> DeleteSubCategoryUseCase {
+        let repository = makeCategoryRepository()
+        return DeleteSubCategoryUseCaseImpl(categoryRepository: repository)
+    }
+
     /// Production ImportRecommendedCategoriesUseCase를 생성합니다
     func makeImportRecommendedCategoriesUseCase() -> ImportRecommendedCategoriesUseCase {
         let categoryRepository = makeCategoryRepository()

--- a/MoneyMoa/Core/Types.swift
+++ b/MoneyMoa/Core/Types.swift
@@ -154,6 +154,7 @@ public enum RepositoryError: Error, Sendable {
     case cannotDeleteActiveCategory
     case cannotDeleteActiveSubCategory
     case cannotDeleteActivePaymentMethod
+    case hasActiveTemplates
     case databaseError(Error)
     case custom(String)
 }

--- a/MoneyMoa/Data/Repository/CategoryRepositoryImpl.swift
+++ b/MoneyMoa/Data/Repository/CategoryRepositoryImpl.swift
@@ -140,7 +140,7 @@ public class CategoryRepositoryImpl: CategoryRepository {
     public func fetchSubCategories(categoryId: UUID) async throws -> [SubCategoryDTO] {
         try await database.withModelContext { context in
             let predicate = #Predicate<SubCategory> { subCategory in
-                subCategory.category.id == categoryId && subCategory.isActive == true
+                subCategory.category?.id == categoryId && subCategory.isActive == true
             }
             let descriptor = self.createSubCategoryDescriptor(predicate: predicate)
             let subCategories = try context.fetch(descriptor)
@@ -166,43 +166,93 @@ public class CategoryRepositoryImpl: CategoryRepository {
             guard let existingSubCategory = try self.fetchSubCategoryModel(id: subCategory.id, context: context) else {
                 throw RepositoryError.subCategoryNotFound
             }
-            
-            if existingSubCategory.category.id != subCategory.categoryId {
+
+            if existingSubCategory.category?.id != subCategory.categoryId {
                 guard let newParentCategory = try self.fetchCategoryModel(id: subCategory.categoryId, context: context) else {
                     throw RepositoryError.categoryNotFound
                 }
                 existingSubCategory.category = newParentCategory
             }
-            
+
             existingSubCategory.name = subCategory.name
             existingSubCategory.transactionType = subCategory.transactionType
             existingSubCategory.isActive = subCategory.isActive
             existingSubCategory.orderIndex = subCategory.orderIndex
-            
+
             try context.save()
         }
     }
     
     // MARK: - SubCategory 검증 (Validation)
-    
+
     public func validateSubCategoryName(_ name: String, categoryId: UUID, excludingId: UUID?) async throws -> Bool {
         try await database.withModelContext { context in
             let predicate: Predicate<SubCategory>
             if let excludingId = excludingId {
                 predicate = #Predicate<SubCategory> { subCategory in
-                    subCategory.name == name && 
-                    subCategory.category.id == categoryId &&
+                    subCategory.name == name &&
+                    subCategory.category?.id == categoryId &&
                     subCategory.id != excludingId
                 }
             } else {
                 predicate = #Predicate<SubCategory> { subCategory in
-                    subCategory.name == name && subCategory.category.id == categoryId
+                    subCategory.name == name && subCategory.category?.id == categoryId
                 }
             }
-            
+
             let descriptor = FetchDescriptor<SubCategory>(predicate: predicate)
             return try context.fetch(descriptor).isEmpty
         }
     }
-    
+
+    // MARK: - 삭제 (Delete Operations)
+
+    public func deleteCategory(_ id: UUID) async throws {
+        try await database.withModelContext { context in
+            guard let category = try self.fetchCategoryModel(id: id, context: context) else {
+                throw RepositoryError.categoryNotFound
+            }
+
+            // 모든 SubCategory의 Transaction 확인
+            let hasTransactions = category.subCategories.contains { subCategory in
+                !subCategory.transactions.isEmpty
+            }
+
+            if hasTransactions {
+                // Transaction이 있으면 soft delete: Category와 모든 SubCategory를 비활성화
+                category.isActive = false
+                for subCategory in category.subCategories {
+                    subCategory.isActive = false
+                }
+            } else {
+                // Transaction이 없으면 hard delete: SubCategory들 먼저 삭제 후 Category 삭제
+//                let subCategoriesToDelete = category.subCategories
+//                for subCategory in subCategoriesToDelete {
+//                    context.delete(subCategory)
+//                }
+                context.delete(category)
+            }
+
+            try context.save()
+        }
+    }
+
+    public func deleteSubCategory(_ id: UUID) async throws {
+        try await database.withModelContext { context in
+            guard let subCategory = try self.fetchSubCategoryModel(id: id, context: context) else {
+                throw RepositoryError.subCategoryNotFound
+            }
+
+            if subCategory.transactions.isEmpty {
+                // Transaction이 없으면 hard delete
+                context.delete(subCategory)
+            } else {
+                // Transaction이 있으면 soft delete
+                subCategory.isActive = false
+            }
+
+            try context.save()
+        }
+    }
+
 }

--- a/MoneyMoa/Data/Repository/CategoryRepositoryImpl.swift
+++ b/MoneyMoa/Data/Repository/CategoryRepositoryImpl.swift
@@ -78,7 +78,8 @@ public class CategoryRepositoryImpl: CategoryRepository {
     public func fetchCategoriesByType(_ type: TransactionType) async throws -> [CategoryDTO] {
         try await database.withModelContext { context in
             let predicate = #Predicate<Category> { category in
-                category.transactionTypeRawValue == type.rawValue
+                category.transactionTypeRawValue == type.rawValue &&
+                category.isActive
             }
             let descriptor = self.createCategoryDescriptor(predicate: predicate)
             let categories = try context.fetch(descriptor)

--- a/MoneyMoa/Data/Repository/CategoryRepositoryImpl.swift
+++ b/MoneyMoa/Data/Repository/CategoryRepositoryImpl.swift
@@ -214,23 +214,28 @@ public class CategoryRepositoryImpl: CategoryRepository {
                 throw RepositoryError.categoryNotFound
             }
 
-            // 모든 SubCategory의 Transaction 확인
+            // TransactionTemplate 확인
+            let hasTemplates = category.subCategories.contains { subCategory in
+                !subCategory.transactionTemplates.isEmpty
+            }
+
+            if hasTemplates {
+                throw RepositoryError.hasActiveTemplates
+            }
+
+            // Transaction 확인
             let hasTransactions = category.subCategories.contains { subCategory in
                 !subCategory.transactions.isEmpty
             }
 
             if hasTransactions {
-                // Transaction이 있으면 soft delete: Category와 모든 SubCategory를 비활성화
+                // Transaction이 있으면 soft delete
                 category.isActive = false
                 for subCategory in category.subCategories {
                     subCategory.isActive = false
                 }
             } else {
-                // Transaction이 없으면 hard delete: SubCategory들 먼저 삭제 후 Category 삭제
-//                let subCategoriesToDelete = category.subCategories
-//                for subCategory in subCategoriesToDelete {
-//                    context.delete(subCategory)
-//                }
+                // 참조가 없으면 hard delete
                 context.delete(category)
             }
 
@@ -244,12 +249,18 @@ public class CategoryRepositoryImpl: CategoryRepository {
                 throw RepositoryError.subCategoryNotFound
             }
 
-            if subCategory.transactions.isEmpty {
-                // Transaction이 없으면 hard delete
-                context.delete(subCategory)
-            } else {
+            // TransactionTemplate 확인
+            if !subCategory.transactionTemplates.isEmpty {
+                throw RepositoryError.hasActiveTemplates
+            }
+
+            // Transaction 확인
+            if !subCategory.transactions.isEmpty {
                 // Transaction이 있으면 soft delete
                 subCategory.isActive = false
+            } else {
+                // 참조가 없으면 hard delete
+                context.delete(subCategory)
             }
 
             try context.save()

--- a/MoneyMoa/Data/SwiftDataModel/Categories.swift
+++ b/MoneyMoa/Data/SwiftDataModel/Categories.swift
@@ -59,15 +59,15 @@ final class SubCategory {
     var isActive: Bool
     
     @Relationship
-    var category: Category
+    var category: Category?
     @Relationship(deleteRule: .cascade, inverse: \Transaction.subCategory)
     var transactions: [Transaction]
-    
+
     init(id: UUID = UUID(),
          name: String,
          transactionType: TransactionType,
          orderIndex: Int = 0,
-         category: Category,
+         category: Category?,
          isActive: Bool = true,
          transactions: [Transaction] = []
     ) {
@@ -104,15 +104,19 @@ extension Category {
 extension SubCategory {
     /// SubCategory를 SubCategoryDTO로 변환
     public func toDTO() -> SubCategoryDTO {
+        guard let category = self.category else {
+            fatalError("SubCategory must have a parent Category")
+        }
+
         return SubCategoryDTO(
             id: self.id,
             name: self.name,
             transactionType: self.transactionType,
             isActive: self.isActive,
             orderIndex: self.orderIndex,
-            categoryId: self.category.id,
-            categoryName: self.category.name,
-            categoryIconName: self.category.iconName
+            categoryId: category.id,
+            categoryName: category.name,
+            categoryIconName: category.iconName
         )
     }
 }

--- a/MoneyMoa/Data/SwiftDataModel/Categories.swift
+++ b/MoneyMoa/Data/SwiftDataModel/Categories.swift
@@ -133,7 +133,7 @@ extension Collection where Element == Category {
 extension Collection where Element == SubCategory {
     /// SubCategory 배열을 SubCategoryDTO 배열로 변환
     func toDTOs() -> [SubCategoryDTO] {
-        return self.map { $0.toDTO() }.sorted(by: { $0.orderIndex < $1.orderIndex })
+        return self.compactMap { $0.isActive ? $0.toDTO() : nil }.sorted(by: { $0.orderIndex < $1.orderIndex })
     }
 }
 

--- a/MoneyMoa/Data/SwiftDataModel/Categories.swift
+++ b/MoneyMoa/Data/SwiftDataModel/Categories.swift
@@ -62,6 +62,8 @@ final class SubCategory {
     var category: Category?
     @Relationship(deleteRule: .cascade, inverse: \Transaction.subCategory)
     var transactions: [Transaction]
+    @Relationship(deleteRule: .cascade, inverse: \TransactionTemplate.subCategory)
+    var transactionTemplates: [TransactionTemplate] = []
 
     init(id: UUID = UUID(),
          name: String,

--- a/MoneyMoa/Domain/DI/DIContainer.swift
+++ b/MoneyMoa/Domain/DI/DIContainer.swift
@@ -95,6 +95,12 @@ protocol DIContainer {
     /// UpdateSubCategoryUseCase를 생성합니다
     func makeUpdateSubCategoryUseCase() -> UpdateSubCategoryUseCase
 
+    /// DeleteCategoryUseCase를 생성합니다
+    func makeDeleteCategoryUseCase() -> DeleteCategoryUseCase
+
+    /// DeleteSubCategoryUseCase를 생성합니다
+    func makeDeleteSubCategoryUseCase() -> DeleteSubCategoryUseCase
+
     /// ImportRecommendedCategoriesUseCase를 생성합니다
     func makeImportRecommendedCategoriesUseCase() -> ImportRecommendedCategoriesUseCase
     
@@ -329,6 +335,7 @@ extension DIContainer {
             createCategoryUseCase: makeCreateCategoryUseCase(),
             createSubCategoryUseCase: makeCreateSubCategoryUseCase(),
             updateCategoryUseCase: makeUpdateCategoryUseCase(),
+            deleteCategoryUseCase: makeDeleteCategoryUseCase(),
             categoryEventPublisher: makeCategoryEventPublisher(),
             mode: mode,
             selectedTransactionType: transactionType ?? .income,
@@ -340,6 +347,7 @@ extension DIContainer {
         return SubCategoryFormViewModel(
             createSubCategoryUseCase: makeCreateSubCategoryUseCase(),
             updateSubCategoryUseCase: makeUpdateSubCategoryUseCase(),
+            deleteSubCategoryUseCase: makeDeleteSubCategoryUseCase(),
             subCategoryEventPublisher: DefaultSubCategoryEventPublisher.shared,
             selectedCategory: category,
             selectedSubCategory: subCategory

--- a/MoneyMoa/Domain/DI/MockDIContainer.swift
+++ b/MoneyMoa/Domain/DI/MockDIContainer.swift
@@ -274,6 +274,18 @@ final class MockDIContainer: DIContainer {
         let categoryRepository = makeCategoryRepository()
         return CreateSubCategoryUseCaseImpl(categoryRepository: categoryRepository)
     }
+
+    /// Mock Repository 기반 DeleteCategoryUseCase를 생성합니다
+    func makeDeleteCategoryUseCase() -> DeleteCategoryUseCase {
+        let categoryRepository = makeCategoryRepository()
+        return DeleteCategoryUseCaseImpl(categoryRepository: categoryRepository)
+    }
+
+    /// Mock Repository 기반 DeleteSubCategoryUseCase를 생성합니다
+    func makeDeleteSubCategoryUseCase() -> DeleteSubCategoryUseCase {
+        let categoryRepository = makeCategoryRepository()
+        return DeleteSubCategoryUseCaseImpl(categoryRepository: categoryRepository)
+    }
     
     /// Mock ImportRecommendedCategoriesUseCase를 생성합니다
     func makeImportRecommendedCategoriesUseCase() -> ImportRecommendedCategoriesUseCase {

--- a/MoneyMoa/Domain/Repository/Category/CategoryRepositories.swift
+++ b/MoneyMoa/Domain/Repository/Category/CategoryRepositories.swift
@@ -75,7 +75,21 @@ public protocol CategoryWriter {
     /// - Parameter subCategory: 수정할 서브카테고리 정보
     /// - Throws: 존재하지 않는 서브카테고리, 중복 이름 등의 에러
     func updateSubCategory(_ subCategory: SubCategoryDTO) async throws
-    
+
+    // MARK: - Category/SubCategory 삭제 (Delete Operations)
+
+    /// 카테고리 삭제
+    /// - Parameter id: 삭제할 카테고리 ID
+    /// - Note: SubCategory에 Transaction이 있으면 isActive=false, 없으면 물리 삭제
+    /// - Throws: 존재하지 않는 카테고리 등의 에러
+    func deleteCategory(_ id: UUID) async throws
+
+    /// 서브카테고리 삭제
+    /// - Parameter id: 삭제할 서브카테고리 ID
+    /// - Note: Transaction이 있으면 isActive=false, 없으면 물리 삭제
+    /// - Throws: 존재하지 않는 서브카테고리 등의 에러
+    func deleteSubCategory(_ id: UUID) async throws
+
 }
 
 /// 통합 카테고리 저장소 프로토콜 (읽기 + 쓰기)

--- a/MoneyMoa/Domain/Repository/Category/MockCategoryRepository.swift
+++ b/MoneyMoa/Domain/Repository/Category/MockCategoryRepository.swift
@@ -14,15 +14,29 @@ import Foundation
 public final class MockCategoryRepository: @unchecked Sendable, CategoryRepository {
 
     // MARK: - Mock Control Properties
-    
+
     /// Simulated delay for async operations (seconds)
     public var delay: TimeInterval = 0
-    
+
     /// Flag to simulate failures
     public var shouldFail = false
-    
+
     /// Custom error to throw when shouldFail is true
     public var errorToThrow: Error = MockError.simulatedFailure
+
+    // MARK: - Tracking Properties
+
+    /// Tracks if deleteCategory was called
+    public var deleteCategoryCalled = false
+
+    /// Tracks the last deleted category ID
+    public var lastDeletedCategoryId: UUID?
+
+    /// Tracks if deleteSubCategory was called
+    public var deleteSubCategoryCalled = false
+
+    /// Tracks the last deleted subcategory ID
+    public var lastDeletedSubCategoryId: UUID?
     
     // MARK: - Data Storage
     
@@ -254,6 +268,9 @@ public final class MockCategoryRepository: @unchecked Sendable, CategoryReposito
 
         return try await withCheckedThrowingContinuation { continuation in
             serialQueue.async {
+                self.deleteCategoryCalled = true
+                self.lastDeletedCategoryId = id
+
                 guard self.categories.contains(where: { $0.id == id }) else {
                     continuation.resume(throwing: MockError.categoryNotFound)
                     return
@@ -273,6 +290,9 @@ public final class MockCategoryRepository: @unchecked Sendable, CategoryReposito
 
         return try await withCheckedThrowingContinuation { continuation in
             serialQueue.async {
+                self.deleteSubCategoryCalled = true
+                self.lastDeletedSubCategoryId = id
+
                 guard self.subCategories.contains(where: { $0.id == id }) else {
                     continuation.resume(throwing: MockError.subCategoryNotFound)
                     return

--- a/MoneyMoa/Domain/Repository/Category/MockCategoryRepository.swift
+++ b/MoneyMoa/Domain/Repository/Category/MockCategoryRepository.swift
@@ -228,7 +228,7 @@ public final class MockCategoryRepository: @unchecked Sendable, CategoryReposito
     public func updateSubCategory(_ subCategory: SubCategoryDTO) async throws {
         try await simulateDelay()
         try checkFailure()
-        
+
         return try await withCheckedThrowingContinuation { continuation in
             serialQueue.async {
                 if let index = self.subCategories.firstIndex(where: { $0.id == subCategory.id }) {
@@ -245,5 +245,44 @@ public final class MockCategoryRepository: @unchecked Sendable, CategoryReposito
             }
         }
     }
-    
+
+    // MARK: - Delete Implementation
+
+    public func deleteCategory(_ id: UUID) async throws {
+        try await simulateDelay()
+        try checkFailure()
+
+        return try await withCheckedThrowingContinuation { continuation in
+            serialQueue.async {
+                guard self.categories.contains(where: { $0.id == id }) else {
+                    continuation.resume(throwing: MockError.categoryNotFound)
+                    return
+                }
+
+                // Mock은 Transaction이 없다고 가정하고 hard delete 수행
+                self.categories.removeAll { $0.id == id }
+                self.subCategories.removeAll { $0.categoryId == id }
+                continuation.resume()
+            }
+        }
+    }
+
+    public func deleteSubCategory(_ id: UUID) async throws {
+        try await simulateDelay()
+        try checkFailure()
+
+        return try await withCheckedThrowingContinuation { continuation in
+            serialQueue.async {
+                guard self.subCategories.contains(where: { $0.id == id }) else {
+                    continuation.resume(throwing: MockError.subCategoryNotFound)
+                    return
+                }
+
+                // Mock은 Transaction이 없다고 가정하고 hard delete 수행
+                self.subCategories.removeAll { $0.id == id }
+                continuation.resume()
+            }
+        }
+    }
+
 }

--- a/MoneyMoa/Domain/UseCases/Category/DeleteCategoryUseCase/DeleteCategoryUseCase.swift
+++ b/MoneyMoa/Domain/UseCases/Category/DeleteCategoryUseCase/DeleteCategoryUseCase.swift
@@ -1,0 +1,16 @@
+//
+//  DeleteCategoryUseCase.swift
+//  MoneyMoa
+//
+//  Created by Sooik Kim on 10/16/25.
+//
+
+import Foundation
+
+public protocol DeleteCategoryUseCase {
+    /// 카테고리를 삭제합니다
+    /// - Parameter id: 삭제할 카테고리 ID
+    /// - Note: SubCategory에 Transaction이 있으면 soft delete, 없으면 hard delete
+    /// - Throws: 카테고리를 찾을 수 없는 경우 등의 에러
+    func execute(_ id: UUID) async throws
+}

--- a/MoneyMoa/Domain/UseCases/Category/DeleteCategoryUseCase/DeleteCategoryUseCaseImpl.swift
+++ b/MoneyMoa/Domain/UseCases/Category/DeleteCategoryUseCase/DeleteCategoryUseCaseImpl.swift
@@ -1,0 +1,21 @@
+//
+//  DeleteCategoryUseCaseImpl.swift
+//  MoneyMoa
+//
+//  Created by Sooik Kim on 10/16/25.
+//
+
+import Foundation
+
+final class DeleteCategoryUseCaseImpl: DeleteCategoryUseCase {
+    private let categoryRepository: CategoryRepository
+
+    init(categoryRepository: CategoryRepository) {
+        self.categoryRepository = categoryRepository
+    }
+
+    func execute(_ id: UUID) async throws {
+        // Repository에서 삭제 로직 처리 (Transaction 확인 후 soft/hard delete)
+        try await categoryRepository.deleteCategory(id)
+    }
+}

--- a/MoneyMoa/Domain/UseCases/Category/DeleteSubCategoryUseCase/DeleteSubCategoryUseCase.swift
+++ b/MoneyMoa/Domain/UseCases/Category/DeleteSubCategoryUseCase/DeleteSubCategoryUseCase.swift
@@ -1,0 +1,16 @@
+//
+//  DeleteSubCategoryUseCase.swift
+//  MoneyMoa
+//
+//  Created by Sooik Kim on 10/16/25.
+//
+
+import Foundation
+
+public protocol DeleteSubCategoryUseCase {
+    /// 서브카테고리를 삭제합니다
+    /// - Parameter id: 삭제할 서브카테고리 ID
+    /// - Note: Transaction이 있으면 soft delete, 없으면 hard delete
+    /// - Throws: 서브카테고리를 찾을 수 없는 경우 등의 에러
+    func execute(_ id: UUID) async throws
+}

--- a/MoneyMoa/Domain/UseCases/Category/DeleteSubCategoryUseCase/DeleteSubCategoryUseCaseImpl.swift
+++ b/MoneyMoa/Domain/UseCases/Category/DeleteSubCategoryUseCase/DeleteSubCategoryUseCaseImpl.swift
@@ -1,0 +1,21 @@
+//
+//  DeleteSubCategoryUseCaseImpl.swift
+//  MoneyMoa
+//
+//  Created by Sooik Kim on 10/16/25.
+//
+
+import Foundation
+
+final class DeleteSubCategoryUseCaseImpl: DeleteSubCategoryUseCase {
+    private let categoryRepository: CategoryRepository
+
+    init(categoryRepository: CategoryRepository) {
+        self.categoryRepository = categoryRepository
+    }
+
+    func execute(_ id: UUID) async throws {
+        // Repository에서 삭제 로직 처리 (Transaction 확인 후 soft/hard delete)
+        try await categoryRepository.deleteSubCategory(id)
+    }
+}

--- a/MoneyMoa/Presentation/Category/NewCategoryForm/CategoryFormView.swift
+++ b/MoneyMoa/Presentation/Category/NewCategoryForm/CategoryFormView.swift
@@ -78,6 +78,11 @@ struct CategoryFormView: View {
         } message: {
             Text("이 카테고리를 삭제하시겠습니까?\n연결된 모든 서브카테고리도 함께 삭제됩니다.")
         }
+        .alert("오류", isPresented: $viewModel.showingErrorAlert) {
+            Button("확인", role: .cancel) {}
+        } message: {
+            Text(viewModel.errorMessage ?? "알 수 없는 오류가 발생했습니다.\n잠시 후 다시 시도해주세요.")
+        }
     }
 
     @ViewBuilder

--- a/MoneyMoa/Presentation/Category/NewCategoryForm/CategoryFormView.swift
+++ b/MoneyMoa/Presentation/Category/NewCategoryForm/CategoryFormView.swift
@@ -44,6 +44,16 @@ struct CategoryFormView: View {
                 }
                 .disabled(!viewModel.isValid)
             }
+
+            if viewModel.selectedCategory != nil {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(role: .destructive) {
+                        viewModel.send(.showDeleteConfirmation)
+                    } label: {
+                        Text("삭제")
+                    }
+                }
+            }
         }
         .alert("서브카테고리 추가", isPresented: $viewModel.showingAddSubCategoryAlert) {
             TextField("서브카테고리 이름", text: $viewModel.newSubCategoryName)
@@ -59,6 +69,14 @@ struct CategoryFormView: View {
             } else {
                 Text("새로운 서브카테고리를 추가하세요.")
             }
+        }
+        .alert("카테고리 삭제", isPresented: $viewModel.showingDeleteConfirmation) {
+            Button("삭제", role: .destructive) {
+                viewModel.send(.deleteCategory(router))
+            }
+            Button("취소", role: .cancel) {}
+        } message: {
+            Text("이 카테고리를 삭제하시겠습니까?\n연결된 모든 서브카테고리도 함께 삭제됩니다.")
         }
     }
 

--- a/MoneyMoa/Presentation/Category/NewCategoryForm/CategoryFormViewModel.swift
+++ b/MoneyMoa/Presentation/Category/NewCategoryForm/CategoryFormViewModel.swift
@@ -30,8 +30,18 @@ final class CategoryFormViewModel {
     
     // Alert 관련 상태
     var showingAddSubCategoryAlert: Bool = false
-    var showingDeleteConfirmation: Bool = false
     var alertErrorMessage: String?
+
+    var showingDeleteConfirmation: Bool = false
+
+    var showingErrorAlert: Bool = false {
+        didSet {
+            if !showingErrorAlert {
+                errorMessage = nil
+            }
+        }
+    }
+    var errorMessage: String?
 
     var isChanged: Bool = false
 
@@ -350,6 +360,16 @@ final class CategoryFormViewModel {
     }
 
     private func handleError(_ error: Error) {
-        print(error.localizedDescription)
+        if let repositoryError = error as? RepositoryError {
+            switch repositoryError {
+            case .hasActiveTemplates:
+                errorMessage = "현재 해당 항목을 사용 중인 거래 템플릿이 있습니다.\n템플릿을 먼저 삭제한 후 다시 시도해주세요."
+            default:
+                errorMessage = "알 수 없는 오류가 발생했습니다.\n잠시 후 다시 시도해주세요."
+            }
+        } else {
+            errorMessage = "알 수 없는 오류가 발생했습니다.\n잠시 후 다시 시도해주세요."
+        }
+        showingErrorAlert = true
     }
 }

--- a/MoneyMoa/Presentation/Category/NewCategoryForm/CategoryFormViewModel.swift
+++ b/MoneyMoa/Presentation/Category/NewCategoryForm/CategoryFormViewModel.swift
@@ -15,6 +15,7 @@ final class CategoryFormViewModel {
     private var createCategoryUseCase: CreateCategoryUseCase
     private var createSubCategoryUseCase: CreateSubCategoryUseCase
     private var updateCategoryUseCase: UpdateCategoryUseCase
+    private var deleteCategoryUseCase: DeleteCategoryUseCase
     private var categoryEventPublisher: any CategoryEventPublisher
 
     let mode: CategoryListMode
@@ -29,6 +30,7 @@ final class CategoryFormViewModel {
     
     // Alert 관련 상태
     var showingAddSubCategoryAlert: Bool = false
+    var showingDeleteConfirmation: Bool = false
     var alertErrorMessage: String?
 
     var isChanged: Bool = false
@@ -63,6 +65,7 @@ final class CategoryFormViewModel {
     init(createCategoryUseCase: CreateCategoryUseCase,
          createSubCategoryUseCase: CreateSubCategoryUseCase,
          updateCategoryUseCase: UpdateCategoryUseCase,
+         deleteCategoryUseCase: DeleteCategoryUseCase,
          categoryEventPublisher: any CategoryEventPublisher,
          mode: CategoryListMode,
          selectedTransactionType: TransactionType = .income,
@@ -71,6 +74,7 @@ final class CategoryFormViewModel {
         self.createCategoryUseCase = createCategoryUseCase
         self.createSubCategoryUseCase = createSubCategoryUseCase
         self.updateCategoryUseCase = updateCategoryUseCase
+        self.deleteCategoryUseCase = deleteCategoryUseCase
         self.categoryEventPublisher = categoryEventPublisher
         self.mode = mode
         self.id = selectedCategory?.id ?? UUID()
@@ -88,6 +92,8 @@ final class CategoryFormViewModel {
         case showAddSubCategoryAlert
         case addSubCategory
         case cancelAddSubCategory
+        case showDeleteConfirmation
+        case deleteCategory(AppRouter)
         case handleError(Error)
     }
 
@@ -98,12 +104,18 @@ final class CategoryFormViewModel {
 
         case .showAddSubCategoryAlert:
             showingAddSubCategoryAlert = true
-            
+
         case .addSubCategory:
             addSubCategory()
 
         case .cancelAddSubCategory:
             cancelAddSubCategory()
+
+        case .showDeleteConfirmation:
+            showingDeleteConfirmation = true
+
+        case .deleteCategory(let router):
+            handleDeleteCategory(router)
 
         case .handleError(let error):
             handleError(error)
@@ -318,6 +330,23 @@ final class CategoryFormViewModel {
         showingAddSubCategoryAlert = false
         newSubCategoryName = ""
         alertErrorMessage = nil
+    }
+
+    private func handleDeleteCategory(_ router: AppRouter) {
+        Task {
+            do {
+                guard let selectedCategory = selectedCategory else { return }
+
+                try await deleteCategoryUseCase.execute(selectedCategory.id)
+
+                // 삭제 이벤트 발행
+                categoryEventPublisher.publish(.init(type: .deleted, category: selectedCategory))
+
+                await router.dismissModal()
+            } catch {
+                self.send(.handleError(error))
+            }
+        }
     }
 
     private func handleError(_ error: Error) {

--- a/MoneyMoa/Presentation/Category/SubCategoryForm/SubCategoryFormView.swift
+++ b/MoneyMoa/Presentation/Category/SubCategoryForm/SubCategoryFormView.swift
@@ -59,6 +59,11 @@ struct SubCategoryFormView: View {
         } message: {
             Text("이 서브카테고리를 삭제하시겠습니까?")
         }
+        .alert("오류", isPresented: $viewModel.showingErrorAlert) {
+            Button("확인", role: .cancel) {}
+        } message: {
+            Text(viewModel.errorMessage ?? "알 수 없는 오류가 발생했습니다.\n잠시 후 다시 시도해주세요.")
+        }
     }
     
     @ViewBuilder

--- a/MoneyMoa/Presentation/Category/SubCategoryForm/SubCategoryFormView.swift
+++ b/MoneyMoa/Presentation/Category/SubCategoryForm/SubCategoryFormView.swift
@@ -22,11 +22,22 @@ struct SubCategoryFormView: View {
         .navigationTitle(viewModel.selectedSubCategoryDTO == nil ? "새 서브카테고리" : "서브카테고리 편집")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button("취소") {
-                    router.dismissModal()
+            if viewModel.selectedSubCategoryDTO != nil {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(role: .destructive) {
+                        viewModel.send(.showDeleteConfirmation)
+                    } label: {
+                        Text("삭제")
+                    }
+                }
+            } else {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("취소") {
+                        router.dismissModal()
+                    }
                 }
             }
+
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("저장") {
                      viewModel.send(.submit(router))
@@ -40,6 +51,14 @@ struct SubCategoryFormView: View {
                 viewModel.send(.unsubscribe)
             }
         })
+        .alert("서브카테고리 삭제", isPresented: $viewModel.showingDeleteConfirmation) {
+            Button("삭제", role: .destructive) {
+                viewModel.send(.deleteSubCategory(router))
+            }
+            Button("취소", role: .cancel) {}
+        } message: {
+            Text("이 서브카테고리를 삭제하시겠습니까?")
+        }
     }
     
     @ViewBuilder

--- a/MoneyMoa/Presentation/Category/SubCategoryForm/SubCategoryFormViewModel.swift
+++ b/MoneyMoa/Presentation/Category/SubCategoryForm/SubCategoryFormViewModel.swift
@@ -21,6 +21,14 @@ final class SubCategoryFormViewModel {
     var selectedSubCategoryDTO: SubCategoryDTO?
     var subCategoryName: String = ""
     var showingDeleteConfirmation: Bool = false
+    var showingErrorAlert: Bool = false {
+        didSet {
+            if !showingErrorAlert {
+                errorMessage = nil
+            }
+        }
+    }
+    var errorMessage: String?
 
     var cancellables: Set<AnyCancellable> = []
 
@@ -53,6 +61,7 @@ final class SubCategoryFormViewModel {
         case showDeleteConfirmation
         case deleteSubCategory(AppRouter)
         case unsubscribe
+        case handleError(Error)
     }
 
     func send(_ action: Action) {
@@ -77,6 +86,9 @@ final class SubCategoryFormViewModel {
 
         case .unsubscribe:
             self.cancellables.removeAll()
+
+        case .handleError(let error):
+            handleError(error)
         }
     }
 
@@ -141,8 +153,22 @@ final class SubCategoryFormViewModel {
 
                 await router.dismissModal()
             } catch {
-                print("서브카테고리 삭제 실패: \(error.localizedDescription)")
+                self.send(.handleError(error))
             }
         }
+    }
+
+    private func handleError(_ error: Error) {
+        if let repositoryError = error as? RepositoryError {
+            switch repositoryError {
+            case .hasActiveTemplates:
+                errorMessage = "현재 해당 항목을 사용 중인 거래 템플릿이 있습니다.\n템플릿을 먼저 삭제한 후 다시 시도해주세요."
+            default:
+                errorMessage = "알 수 없는 오류가 발생했습니다.\n잠시 후 다시 시도해주세요."
+            }
+        } else {
+            errorMessage = "알 수 없는 오류가 발생했습니다.\n잠시 후 다시 시도해주세요."
+        }
+        showingErrorAlert = true
     }
 }

--- a/MoneyMoa/Presentation/Category/SubCategoryForm/SubCategoryFormViewModel.swift
+++ b/MoneyMoa/Presentation/Category/SubCategoryForm/SubCategoryFormViewModel.swift
@@ -14,11 +14,13 @@ final class SubCategoryFormViewModel {
 
     private var createSubCategoryUseCase: CreateSubCategoryUseCase
     private var updateSubCategoryUseCase: UpdateSubCategoryUseCase
+    private var deleteSubCategoryUseCase: DeleteSubCategoryUseCase
     private var subCategoryEventPublisher: any SubCategoryEventPublisher
 
     var selectedCategory: CategoryDTO
     var selectedSubCategoryDTO: SubCategoryDTO?
     var subCategoryName: String = ""
+    var showingDeleteConfirmation: Bool = false
 
     var cancellables: Set<AnyCancellable> = []
 
@@ -30,12 +32,14 @@ final class SubCategoryFormViewModel {
 
     init(createSubCategoryUseCase: CreateSubCategoryUseCase,
          updateSubCategoryUseCase: UpdateSubCategoryUseCase,
+         deleteSubCategoryUseCase: DeleteSubCategoryUseCase,
          subCategoryEventPublisher: any SubCategoryEventPublisher,
          selectedCategory: CategoryDTO,
          selectedSubCategory: SubCategoryDTO? = nil
     ) {
         self.createSubCategoryUseCase = createSubCategoryUseCase
         self.updateSubCategoryUseCase = updateSubCategoryUseCase
+        self.deleteSubCategoryUseCase = deleteSubCategoryUseCase
         self.subCategoryEventPublisher = subCategoryEventPublisher
         self.selectedCategory = selectedCategory
         self.selectedSubCategoryDTO = selectedSubCategory
@@ -46,6 +50,8 @@ final class SubCategoryFormViewModel {
         case submit(AppRouter)
         case showCategorySelector(AppRouter)
         case selectCategory(CategoryDTO)
+        case showDeleteConfirmation
+        case deleteSubCategory(AppRouter)
         case unsubscribe
     }
 
@@ -53,13 +59,21 @@ final class SubCategoryFormViewModel {
         switch action {
         case .submit(let router):
             submit(router)
+
         case .showCategorySelector(let router):
             Task {
                 subscribeSelectCategoryEventPublisher()
                 await router.present(.settings(.categorySelector(selectedCategory)), as: .sheet)
             }
+
         case .selectCategory(let category):
             self.selectedCategory = category
+
+        case .showDeleteConfirmation:
+            showingDeleteConfirmation = true
+
+        case .deleteSubCategory(let router):
+            deleteSubCategory(router)
 
         case .unsubscribe:
             self.cancellables.removeAll()
@@ -81,7 +95,7 @@ final class SubCategoryFormViewModel {
         Task {
             do {
                 let trimmedName = subCategoryName.trimmingCharacters(in: .whitespacesAndNewlines)
-                
+
                 if let existingSubCategory = selectedSubCategoryDTO {
                     // 수정 모드
                     let updatedSubCategory = SubCategoryDTO(
@@ -92,7 +106,7 @@ final class SubCategoryFormViewModel {
                         categoryName: selectedCategory.name,
                         categoryIconName: selectedCategory.iconName
                     )
-                    
+
                     try await updateSubCategoryUseCase.execute(updatedSubCategory)
                     subCategoryEventPublisher.publish(.init(type: .updated, subCategory: updatedSubCategory))
                 } else {
@@ -105,7 +119,7 @@ final class SubCategoryFormViewModel {
                         categoryName: selectedCategory.name,
                         categoryIconName: selectedCategory.iconName
                     )
-                    
+
                     try await createSubCategoryUseCase.execute(newSubCategory)
                     subCategoryEventPublisher.publish(.init(type: .created, subCategory: newSubCategory))
                 }
@@ -113,6 +127,21 @@ final class SubCategoryFormViewModel {
                 await router.dismissModal()
             } catch {
                 print("서브카테고리 처리 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func deleteSubCategory(_ router: AppRouter) {
+        Task {
+            do {
+                guard let selectedSubCategory = selectedSubCategoryDTO else { return }
+
+                try await deleteSubCategoryUseCase.execute(selectedSubCategory.id)
+                subCategoryEventPublisher.publish(.init(type: .deleted, subCategory: selectedSubCategory))
+
+                await router.dismissModal()
+            } catch {
+                print("서브카테고리 삭제 실패: \(error.localizedDescription)")
             }
         }
     }

--- a/MoneyMoa/Presentation/Settings/SettingView.swift
+++ b/MoneyMoa/Presentation/Settings/SettingView.swift
@@ -107,9 +107,9 @@ enum SettingsItem: Hashable {
         case .monthlyBudget:
             router.push(.settingsBudget(YearMonth.current))
         case .transactionTemplate:
-            router.push(.settings(.transactionTemplate))
-        case .categoryManagement:
             router.push(.settingTransactionTemplate)
+        case .categoryManagement:
+            router.push(.categorySetup)
         case .versionInfo, .developerInfo:
             break // No action for info items
         }

--- a/MoneyMoaTests/Data/Repository/CategoryRepositoryTests.swift
+++ b/MoneyMoaTests/Data/Repository/CategoryRepositoryTests.swift
@@ -222,14 +222,195 @@ final class CategoryRepositoryTests: XCTestCase {
         // Given: 카테고리와 서브카테고리 생성
         let category = TestDataFactory.createCategory()
         try await repository.insertCategory(category)
-        
+
         let existingSubCategory = TestDataFactory.createSubCategory(name: "외식비", categoryId: category.id)
         try await repository.insertSubCategory(existingSubCategory)
-        
+
         // When: 같은 이름으로 검증
         let isValid = try await repository.validateSubCategoryName("외식비", categoryId: category.id, excludingId: nil)
-        
+
         // Then: 중복된 이름으로 판단
         XCTAssertFalse(isValid)
+    }
+
+    // MARK: - 삭제 테스트 (Delete Operations)
+
+    func testDeleteCategory_WithoutTransactions_ShouldHardDelete() async throws {
+        // Given: Transaction이 없는 Category와 SubCategory
+        let category = TestDataFactory.createCategory(name: "식비")
+        try await repository.insertCategory(category)
+
+        let subCategory = TestDataFactory.createSubCategory(name: "외식비", categoryId: category.id)
+        try await repository.insertSubCategory(subCategory)
+
+        // When: Category 삭제
+        try await repository.deleteCategory(category.id)
+
+        // Then: Category와 SubCategory가 물리적으로 삭제됨
+        let categories = try await repository.fetchCategories()
+        XCTAssertTrue(categories.isEmpty)
+    }
+
+    func testDeleteCategory_WithTransactions_ShouldSoftDelete() async throws {
+        // Given: Transaction이 있는 Category와 SubCategory
+        let category = TestDataFactory.createCategory(name: "식비")
+        try await repository.insertCategory(category)
+
+        let subCategory = TestDataFactory.createSubCategory(name: "외식비", categoryId: category.id)
+        try await repository.insertSubCategory(subCategory)
+
+        let paymentMethod = TestDataFactory.createPaymentMethod()
+        let paymentMethodRepository = PaymentMethodRepositoryImpl(database: database)
+        try await paymentMethodRepository.insertPaymentMethod(paymentMethod)
+
+        let transaction = TestDataFactory.createTransaction(
+            amount: 10000,
+            subCategory: subCategory,
+            paymentMethod: paymentMethod
+        )
+        let transactionRepository = TransactionRepositoryImpl(database: database)
+        try await transactionRepository.insertTransaction(transaction)
+
+        // When: Category 삭제
+        try await repository.deleteCategory(category.id)
+
+        // Then: Category와 SubCategory의 isActive가 false로 변경됨
+        let categories = try await repository.fetchCategories()
+        XCTAssertEqual(categories.count, 1)
+        XCTAssertFalse(categories[0].isActive)
+
+        let subCategories = try await database.withModelContext { context in
+            let descriptor = FetchDescriptor<SubCategory>()
+            return try context.fetch(descriptor).toDTOs()
+        }
+        XCTAssertEqual(subCategories.count, 1)
+        XCTAssertFalse(subCategories[0].isActive)
+    }
+
+    func testDeleteCategory_NotFound_ShouldThrowError() async throws {
+        // Given: 존재하지 않는 Category ID
+        let nonExistentId = UUID()
+
+        // When/Then: 에러 발생
+        do {
+            try await repository.deleteCategory(nonExistentId)
+            XCTFail("Should throw categoryNotFound error")
+        } catch let error as RepositoryError {
+            switch error {
+            case .categoryNotFound:
+                break // Expected error
+            default:
+                XCTFail("Unexpected error: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testDeleteSubCategory_WithoutTransactions_ShouldHardDelete() async throws {
+        // Given: Transaction이 없는 SubCategory
+        let category = TestDataFactory.createCategory(name: "식비")
+        try await repository.insertCategory(category)
+
+        let subCategory = TestDataFactory.createSubCategory(name: "외식비", categoryId: category.id)
+        try await repository.insertSubCategory(subCategory)
+
+        // When: SubCategory 삭제
+        try await repository.deleteSubCategory(subCategory.id)
+
+        // Then: SubCategory가 물리적으로 삭제됨
+        let subCategories = try await repository.fetchSubCategories(categoryId: category.id)
+        XCTAssertTrue(subCategories.isEmpty)
+    }
+
+    func testDeleteSubCategory_WithTransactions_ShouldSoftDelete() async throws {
+        // Given: Transaction이 있는 SubCategory
+        let category = TestDataFactory.createCategory(name: "식비")
+        try await repository.insertCategory(category)
+
+        let subCategory = TestDataFactory.createSubCategory(name: "외식비", categoryId: category.id)
+        try await repository.insertSubCategory(subCategory)
+
+        let paymentMethod = TestDataFactory.createPaymentMethod()
+        let paymentMethodRepository = PaymentMethodRepositoryImpl(database: database)
+        try await paymentMethodRepository.insertPaymentMethod(paymentMethod)
+
+        let transaction = TestDataFactory.createTransaction(
+            amount: 10000,
+            subCategory: subCategory,
+            paymentMethod: paymentMethod
+        )
+        let transactionRepository = TransactionRepositoryImpl(database: database)
+        try await transactionRepository.insertTransaction(transaction)
+
+        // When: SubCategory 삭제
+        try await repository.deleteSubCategory(subCategory.id)
+
+        // Then: SubCategory의 isActive가 false로 변경됨
+        let subCategories = try await database.withModelContext { context in
+            let descriptor = FetchDescriptor<SubCategory>()
+            return try context.fetch(descriptor).toDTOs()
+        }
+        XCTAssertEqual(subCategories.count, 1)
+        XCTAssertFalse(subCategories[0].isActive)
+    }
+
+    func testDeleteSubCategory_NotFound_ShouldThrowError() async throws {
+        // Given: 존재하지 않는 SubCategory ID
+        let nonExistentId = UUID()
+
+        // When/Then: 에러 발생
+        do {
+            try await repository.deleteSubCategory(nonExistentId)
+            XCTFail("Should throw subCategoryNotFound error")
+        } catch let error as RepositoryError {
+            switch error {
+            case .subCategoryNotFound:
+                break // Expected error
+            default:
+                XCTFail("Unexpected error: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testDeleteCategory_WithMultipleSubCategories_OnlyOneHasTransactions() async throws {
+        // Given: 여러 SubCategory 중 하나만 Transaction을 가진 경우
+        let category = TestDataFactory.createCategory(name: "식비")
+        try await repository.insertCategory(category)
+
+        let subCategory1 = TestDataFactory.createSubCategory(name: "외식비", categoryId: category.id)
+        let subCategory2 = TestDataFactory.createSubCategory(name: "마트", categoryId: category.id)
+        try await repository.insertSubCategory(subCategory1)
+        try await repository.insertSubCategory(subCategory2)
+
+        let paymentMethod = TestDataFactory.createPaymentMethod()
+        let paymentMethodRepository = PaymentMethodRepositoryImpl(database: database)
+        try await paymentMethodRepository.insertPaymentMethod(paymentMethod)
+
+        // subCategory1에만 Transaction 추가
+        let transaction = TestDataFactory.createTransaction(
+            amount: 10000,
+            subCategory: subCategory1,
+            paymentMethod: paymentMethod
+        )
+        let transactionRepository = TransactionRepositoryImpl(database: database)
+        try await transactionRepository.insertTransaction(transaction)
+
+        // When: Category 삭제
+        try await repository.deleteCategory(category.id)
+
+        // Then: Category와 모든 SubCategory가 soft delete됨
+        let categories = try await repository.fetchCategories()
+        XCTAssertEqual(categories.count, 1)
+        XCTAssertFalse(categories[0].isActive)
+
+        let allSubCategories = try await database.withModelContext { context in
+            let descriptor = FetchDescriptor<SubCategory>()
+            return try context.fetch(descriptor).toDTOs()
+        }
+        XCTAssertEqual(allSubCategories.count, 2)
+        XCTAssertTrue(allSubCategories.allSatisfy { !$0.isActive })
     }
 }

--- a/MoneyMoaTests/Data/Repository/CategoryRepositoryTests.swift
+++ b/MoneyMoaTests/Data/Repository/CategoryRepositoryTests.swift
@@ -236,45 +236,25 @@ final class CategoryRepositoryTests: XCTestCase {
     // MARK: - 삭제 테스트 (Delete Operations)
 
     func testDeleteCategory_WithoutTransactions_ShouldHardDelete() async throws {
-        // Given: Transaction이 없는 Category와 SubCategory
-        let category = TestDataFactory.createCategory(name: "식비")
-        try await repository.insertCategory(category)
+        // Given
+        let (category, _) = try await setupCategoryAndSubCategory()
 
-        let subCategory = TestDataFactory.createSubCategory(name: "외식비", categoryId: category.id)
-        try await repository.insertSubCategory(subCategory)
-
-        // When: Category 삭제
+        // When
         try await repository.deleteCategory(category.id)
 
-        // Then: Category와 SubCategory가 물리적으로 삭제됨
+        // Then
         let categories = try await repository.fetchCategories()
         XCTAssertTrue(categories.isEmpty)
     }
 
     func testDeleteCategory_WithTransactions_ShouldSoftDelete() async throws {
-        // Given: Transaction이 있는 Category와 SubCategory
-        let category = TestDataFactory.createCategory(name: "식비")
-        try await repository.insertCategory(category)
+        // Given
+        let (category, _) = try await setupCategoryWithTransaction()
 
-        let subCategory = TestDataFactory.createSubCategory(name: "외식비", categoryId: category.id)
-        try await repository.insertSubCategory(subCategory)
-
-        let paymentMethod = TestDataFactory.createPaymentMethod()
-        let paymentMethodRepository = PaymentMethodRepositoryImpl(database: database)
-        try await paymentMethodRepository.insertPaymentMethod(paymentMethod)
-
-        let transaction = TestDataFactory.createTransaction(
-            amount: 10000,
-            subCategory: subCategory,
-            paymentMethod: paymentMethod
-        )
-        let transactionRepository = TransactionRepositoryImpl(database: database)
-        try await transactionRepository.insertTransaction(transaction)
-
-        // When: Category 삭제
+        // When
         try await repository.deleteCategory(category.id)
 
-        // Then: Category와 SubCategory의 isActive가 false로 변경됨
+        // Then
         let categories = try await repository.fetchCategories()
         XCTAssertEqual(categories.count, 1)
         XCTAssertFalse(categories[0].isActive)
@@ -310,51 +290,30 @@ final class CategoryRepositoryTests: XCTestCase {
     }
 
     func testDeleteSubCategory_WithoutTransactions_ShouldHardDelete() async throws {
-        // Given: Transaction이 없는 SubCategory
-        let category = TestDataFactory.createCategory(name: "식비")
-        try await repository.insertCategory(category)
+        // Given
+        let (category, subCategory) = try await setupCategoryAndSubCategory()
 
-        let subCategory = TestDataFactory.createSubCategory(name: "외식비", categoryId: category.id)
-        try await repository.insertSubCategory(subCategory)
-
-        // When: SubCategory 삭제
+        // When
         try await repository.deleteSubCategory(subCategory.id)
 
-        // Then: SubCategory가 물리적으로 삭제됨
+        // Then
         let subCategories = try await repository.fetchSubCategories(categoryId: category.id)
         XCTAssertTrue(subCategories.isEmpty)
     }
 
     func testDeleteSubCategory_WithTransactions_ShouldSoftDelete() async throws {
-        // Given: Transaction이 있는 SubCategory
-        let category = TestDataFactory.createCategory(name: "식비")
-        try await repository.insertCategory(category)
+        // Given
+        let (_, subCategory) = try await setupCategoryWithTransaction()
 
-        let subCategory = TestDataFactory.createSubCategory(name: "외식비", categoryId: category.id)
-        try await repository.insertSubCategory(subCategory)
-
-        let paymentMethod = TestDataFactory.createPaymentMethod()
-        let paymentMethodRepository = PaymentMethodRepositoryImpl(database: database)
-        try await paymentMethodRepository.insertPaymentMethod(paymentMethod)
-
-        let transaction = TestDataFactory.createTransaction(
-            amount: 10000,
-            subCategory: subCategory,
-            paymentMethod: paymentMethod
-        )
-        let transactionRepository = TransactionRepositoryImpl(database: database)
-        try await transactionRepository.insertTransaction(transaction)
-
-        // When: SubCategory 삭제
+        // When
         try await repository.deleteSubCategory(subCategory.id)
 
-        // Then: SubCategory의 isActive가 false로 변경됨
+        // Then
         let subCategories = try await database.withModelContext { context in
             let descriptor = FetchDescriptor<SubCategory>()
             let subCategories = try context.fetch(descriptor)
             XCTAssertEqual(subCategories.count, 1)
             XCTAssertFalse(subCategories[0].isActive)
-
             return subCategories.toDTOs()
         }
 
@@ -414,9 +373,123 @@ final class CategoryRepositoryTests: XCTestCase {
 
         let allSubCategories = try await database.withModelContext { context in
             let descriptor = FetchDescriptor<SubCategory>()
-            return try context.fetch(descriptor).toDTOs()
+            let allSubCategories = try context.fetch(descriptor)
+            XCTAssertEqual(allSubCategories.count, 2)
+            XCTAssertTrue(allSubCategories.allSatisfy { !$0.isActive })
+            return allSubCategories.toDTOs()
         }
-        XCTAssertEqual(allSubCategories.count, 2)
-        XCTAssertTrue(allSubCategories.allSatisfy { !$0.isActive })
+
+        XCTAssertTrue(allSubCategories.isEmpty)
+    }
+
+    // MARK: - Delete Category with TransactionTemplate Tests
+
+    func test_deleteCategory_withTransactionTemplate_throwsHasActiveTemplatesError() async throws {
+        // Given
+        let (category, _) = try await setupCategoryWithTemplate()
+
+        // When/Then
+        await assertThrowsHasActiveTemplatesError {
+            try await self.repository.deleteCategory(category.id)
+        }
+
+        // Category와 SubCategory는 여전히 active
+        let categories = try await repository.fetchCategories()
+        XCTAssertEqual(categories.count, 1)
+        XCTAssertTrue(categories[0].isActive)
+
+        let subCategories = try await repository.fetchSubCategories(categoryId: category.id)
+        XCTAssertEqual(subCategories.count, 1)
+        XCTAssertTrue(subCategories[0].isActive)
+    }
+
+    func test_deleteSubCategory_withTransactionTemplate_throwsHasActiveTemplatesError() async throws {
+        // Given
+        let (category, subCategory) = try await setupCategoryWithTemplate()
+
+        // When/Then
+        await assertThrowsHasActiveTemplatesError {
+            try await self.repository.deleteSubCategory(subCategory.id)
+        }
+
+        // SubCategory는 여전히 active
+        let subCategories = try await repository.fetchSubCategories(categoryId: category.id)
+        XCTAssertEqual(subCategories.count, 1)
+        XCTAssertTrue(subCategories[0].isActive)
+    }
+
+    // MARK: - Helper Methods
+
+    private func setupCategoryAndSubCategory() async throws -> (CategoryDTO, SubCategoryDTO) {
+        let category = TestDataFactory.createCategory(name: "식비")
+        try await repository.insertCategory(category)
+
+        let subCategory = TestDataFactory.createSubCategory(name: "외식비", categoryId: category.id)
+        try await repository.insertSubCategory(subCategory)
+
+        return (category, subCategory)
+    }
+
+    private func setupCategoryWithTransaction() async throws -> (CategoryDTO, SubCategoryDTO) {
+        let (category, subCategory) = try await setupCategoryAndSubCategory()
+
+        let paymentMethod = TestDataFactory.createPaymentMethod()
+        let paymentMethodRepository = PaymentMethodRepositoryImpl(database: database)
+        try await paymentMethodRepository.insertPaymentMethod(paymentMethod)
+
+        let transaction = TestDataFactory.createTransaction(amount: 10000, subCategory: subCategory, paymentMethod: paymentMethod)
+        let transactionRepository = TransactionRepositoryImpl(database: database)
+        try await transactionRepository.insertTransaction(transaction)
+
+        return (category, subCategory)
+    }
+
+    private func setupCategoryWithTemplate() async throws -> (CategoryDTO, SubCategoryDTO) {
+        let (category, subCategory) = try await setupCategoryAndSubCategory()
+
+        let paymentMethod = TestDataFactory.createPaymentMethod()
+        let paymentMethodRepository = PaymentMethodRepositoryImpl(database: database)
+        try await paymentMethodRepository.insertPaymentMethod(paymentMethod)
+
+        try await createTransactionTemplate(subCategory: subCategory, paymentMethod: paymentMethod)
+
+        return (category, subCategory)
+    }
+
+    private func createTransactionTemplate(subCategory: SubCategoryDTO, paymentMethod: PaymentMethodDTO) async throws {
+        let template = TransactionTemplateDTO(amount: 10000, transactionType: .variableExpense, subCategory: subCategory, paymentMethod: paymentMethod, recurrencePattern: .init(from: Date(), period: .none, calendar: Calendar.current))
+        try await database.withModelContext { context in
+            let subCategoryModel = try self.fetchSubCategoryModel(id: subCategory.id, context: context)!
+            let paymentMethodModel = try self.fetchPaymentMethodModel(id: paymentMethod.id, context: context)!
+            let template = template.toModel(subCategory: subCategoryModel, paymentMethod: paymentMethodModel)
+            context.insert(template)
+            try context.save()
+        }
+    }
+
+    private func assertThrowsHasActiveTemplatesError(_ block: () async throws -> Void) async {
+        do {
+            try await block()
+            XCTFail("Should throw hasActiveTemplates error")
+        } catch let error as RepositoryError {
+            switch error {
+            case .hasActiveTemplates:
+                break // Expected
+            default:
+                XCTFail("Unexpected error: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    private func fetchPaymentMethodModel(id: UUID, context: ModelContext) throws -> PaymentMethod? {
+        let descriptor = FetchDescriptor<PaymentMethod>(predicate: #Predicate { $0.id == id })
+        return try context.fetch(descriptor).first
+    }
+
+    private func fetchSubCategoryModel(id: UUID, context: ModelContext) throws -> SubCategory? {
+        let descriptor = FetchDescriptor<SubCategory>(predicate: #Predicate { $0.id == id })
+        return try context.fetch(descriptor).first
     }
 }

--- a/MoneyMoaTests/Data/Repository/CategoryRepositoryTests.swift
+++ b/MoneyMoaTests/Data/Repository/CategoryRepositoryTests.swift
@@ -281,10 +281,12 @@ final class CategoryRepositoryTests: XCTestCase {
 
         let subCategories = try await database.withModelContext { context in
             let descriptor = FetchDescriptor<SubCategory>()
-            return try context.fetch(descriptor).toDTOs()
+            let subCategories = try context.fetch(descriptor)
+            XCTAssertEqual(subCategories.count, 1)
+            XCTAssertFalse(subCategories[0].isActive)
+            return subCategories.toDTOs()
         }
-        XCTAssertEqual(subCategories.count, 1)
-        XCTAssertFalse(subCategories[0].isActive)
+        XCTAssertTrue(subCategories.isEmpty)
     }
 
     func testDeleteCategory_NotFound_ShouldThrowError() async throws {
@@ -349,10 +351,14 @@ final class CategoryRepositoryTests: XCTestCase {
         // Then: SubCategory의 isActive가 false로 변경됨
         let subCategories = try await database.withModelContext { context in
             let descriptor = FetchDescriptor<SubCategory>()
-            return try context.fetch(descriptor).toDTOs()
+            let subCategories = try context.fetch(descriptor)
+            XCTAssertEqual(subCategories.count, 1)
+            XCTAssertFalse(subCategories[0].isActive)
+
+            return subCategories.toDTOs()
         }
-        XCTAssertEqual(subCategories.count, 1)
-        XCTAssertFalse(subCategories[0].isActive)
+
+        XCTAssertTrue(subCategories.isEmpty)
     }
 
     func testDeleteSubCategory_NotFound_ShouldThrowError() async throws {

--- a/MoneyMoaTests/Domain/UseCases/Category/DeleteCategoryUseCaseTests.swift
+++ b/MoneyMoaTests/Domain/UseCases/Category/DeleteCategoryUseCaseTests.swift
@@ -1,0 +1,67 @@
+//
+//  DeleteCategoryUseCaseTests.swift
+//  MoneyMoaTests
+//
+//  Created by Sooik Kim on 10/16/25.
+//
+
+import XCTest
+@testable import MoneyMoa
+
+// MARK: - DeleteCategoryUseCaseTests
+
+@MainActor
+final class DeleteCategoryUseCaseTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var useCase: DeleteCategoryUseCaseImpl!
+    private var mockRepository: MockCategoryRepository!
+
+    // MARK: - Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+        mockRepository = MockCategoryRepository(scenario: .normal)
+        useCase = DeleteCategoryUseCaseImpl(categoryRepository: mockRepository)
+    }
+
+    override func tearDown() {
+        useCase = nil
+        mockRepository = nil
+        super.tearDown()
+    }
+
+    // MARK: - Test Methods
+
+    func test_execute_callsRepositoryDeleteCategory() async throws {
+        // Given: 실제 존재하는 카테고리 ID
+        let categories = try await mockRepository.fetchCategories()
+        guard let categoryId = categories.first?.id else {
+            XCTFail("No categories found in mock repository")
+            return
+        }
+
+        // When: UseCase execute 호출
+        try await useCase.execute(categoryId)
+
+        // Then: Repository의 deleteCategory가 호출됨
+        XCTAssertTrue(mockRepository.deleteCategoryCalled)
+        XCTAssertEqual(mockRepository.lastDeletedCategoryId, categoryId)
+    }
+
+    func test_execute_propagatesRepositoryError() async throws {
+        // Given: Repository에서 에러가 발생하도록 설정
+        let categoryId = UUID()
+        mockRepository.shouldFail = true
+        mockRepository.errorToThrow = MockError.simulatedFailure
+
+        // When/Then: UseCase가 Repository 에러를 전파
+        do {
+            try await useCase.execute(categoryId)
+            XCTFail("Should propagate repository error")
+        } catch {
+            XCTAssertNotNil(error)
+        }
+    }
+}

--- a/MoneyMoaTests/Domain/UseCases/Category/DeleteSubCategoryUseCaseTests.swift
+++ b/MoneyMoaTests/Domain/UseCases/Category/DeleteSubCategoryUseCaseTests.swift
@@ -1,0 +1,68 @@
+//
+//  DeleteSubCategoryUseCaseTests.swift
+//  MoneyMoaTests
+//
+//  Created by Sooik Kim on 10/16/25.
+//
+
+import XCTest
+@testable import MoneyMoa
+
+// MARK: - DeleteSubCategoryUseCaseTests
+
+@MainActor
+final class DeleteSubCategoryUseCaseTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var useCase: DeleteSubCategoryUseCaseImpl!
+    private var mockRepository: MockCategoryRepository!
+
+    // MARK: - Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+        mockRepository = MockCategoryRepository(scenario: .realistic)
+        useCase = DeleteSubCategoryUseCaseImpl(categoryRepository: mockRepository)
+    }
+
+    override func tearDown() {
+        useCase = nil
+        mockRepository = nil
+        super.tearDown()
+    }
+
+    // MARK: - Test Methods
+
+    func test_execute_callsRepositoryDeleteSubCategory() async throws {
+        // Given: 실제 존재하는 서브카테고리 ID
+        let categories = try await mockRepository.fetchCategoriesByType(.variableExpense)
+        guard let category = categories.first,
+              let subCategoryId = category.subCategories.first?.id else {
+            XCTFail("No subcategories found in mock repository")
+            return
+        }
+
+        // When: UseCase execute 호출
+        try await useCase.execute(subCategoryId)
+
+        // Then: Repository의 deleteSubCategory가 호출됨
+        XCTAssertTrue(mockRepository.deleteSubCategoryCalled)
+        XCTAssertEqual(mockRepository.lastDeletedSubCategoryId, subCategoryId)
+    }
+
+    func test_execute_propagatesRepositoryError() async throws {
+        // Given: Repository에서 에러가 발생하도록 설정
+        let subCategoryId = UUID()
+        mockRepository.shouldFail = true
+        mockRepository.errorToThrow = MockError.simulatedFailure
+
+        // When/Then: UseCase가 Repository 에러를 전파
+        do {
+            try await useCase.execute(subCategoryId)
+            XCTFail("Should propagate repository error")
+        } catch {
+            XCTAssertNotNil(error)
+        }
+    }
+}

--- a/MoneyMoaTests/Domain/UseCases/Category/UpdateCategoryUseCaseTests.swift
+++ b/MoneyMoaTests/Domain/UseCases/Category/UpdateCategoryUseCaseTests.swift
@@ -335,4 +335,8 @@ private class MockCategoryRepository: CategoryRepository {
     func insertSubCategory(_ subCategory: SubCategoryDTO) async throws { }
     func updateSubCategory(_ subCategory: SubCategoryDTO) async throws { }
     func validateSubCategoryName(_ name: String, categoryId: UUID, excludingId: UUID?) async throws -> Bool { true }
+
+    // MARK: - Delete methods
+    func deleteCategory(_ id: UUID) async throws { }
+    func deleteSubCategory(_ id: UUID) async throws { }
 }

--- a/MoneyMoaTests/Domain/UseCases/Category/UpdateSubCategoryUseCaseTests.swift
+++ b/MoneyMoaTests/Domain/UseCases/Category/UpdateSubCategoryUseCaseTests.swift
@@ -367,4 +367,6 @@ private class MockCategoryRepository: CategoryRepository {
     func insertCategory(_ category: CategoryDTO) async throws {}
     func updateCategory(_ category: CategoryDTO) async throws {}
     func insertSubCategory(_ subCategory: SubCategoryDTO) async throws {}
+    func deleteCategory(_ id: UUID) async throws { }
+    func deleteSubCategory(_ id: UUID) async throws { }
 }

--- a/MoneyMoaTests/Extensions/DTOExtensionTests.swift
+++ b/MoneyMoaTests/Extensions/DTOExtensionTests.swift
@@ -61,7 +61,7 @@ final class DTOExtensionTests: XCTestCase {
         XCTAssertEqual(subCategoryModel.transactionType, subCategoryDTO.transactionType)
         XCTAssertEqual(subCategoryModel.isActive, subCategoryDTO.isActive)
         XCTAssertEqual(subCategoryModel.orderIndex, subCategoryDTO.orderIndex)
-        XCTAssertEqual(subCategoryModel.category.id, parentCategory.id)
+        XCTAssertEqual(subCategoryModel.category?.id, parentCategory.id)
     }
     
     // MARK: - PaymentMethodDTO Tests

--- a/MoneyMoaTests/Presentation/Category/NewCategoryForm/CategoryFormViewModelTests.swift
+++ b/MoneyMoaTests/Presentation/Category/NewCategoryForm/CategoryFormViewModelTests.swift
@@ -13,40 +13,43 @@ import Combine
 
 @MainActor
 final class CategoryFormViewModelTests: XCTestCase {
-    
+
     // MARK: - Properties
-    
+
     private var viewModel: CategoryFormViewModel!
     private var mockCreateCategoryUseCase: MockCreateCategoryUseCase!
     private var mockCreateSubCategoryUseCase: MockCreateSubCategoryUseCase!
     private var mockUpdateCategoryUseCase: MockUpdateCategoryUseCase!
+    private var mockDeleteCategoryUseCase: MockDeleteCategoryUseCase!
     private var mockCategoryEventPublisher: MockCategoryEventPublisher!
     private var mockRouter: AppRouter!
-    
+
     // MARK: - Setup & Teardown
-    
+
     override func setUp() {
         super.setUp()
-        
+
         mockCreateCategoryUseCase = MockCreateCategoryUseCase()
         mockCreateSubCategoryUseCase = MockCreateSubCategoryUseCase()
         mockUpdateCategoryUseCase = MockUpdateCategoryUseCase()
+        mockDeleteCategoryUseCase = MockDeleteCategoryUseCase()
         mockCategoryEventPublisher = MockCategoryEventPublisher()
         mockRouter = AppRouter()
     }
-    
+
     override func tearDown() {
         viewModel = nil
         mockCreateCategoryUseCase = nil
         mockCreateSubCategoryUseCase = nil
         mockUpdateCategoryUseCase = nil
+        mockDeleteCategoryUseCase = nil
         mockCategoryEventPublisher = nil
         mockRouter = nil
         super.tearDown()
     }
-    
+
     // MARK: - Helper Methods
-    
+
     private func createViewModel(
         mode: CategoryListMode = .configuration,
         selectedTransactionType: TransactionType = .income,
@@ -56,19 +59,20 @@ final class CategoryFormViewModelTests: XCTestCase {
             createCategoryUseCase: mockCreateCategoryUseCase,
             createSubCategoryUseCase: mockCreateSubCategoryUseCase,
             updateCategoryUseCase: mockUpdateCategoryUseCase,
+            deleteCategoryUseCase: mockDeleteCategoryUseCase,
             categoryEventPublisher: mockCategoryEventPublisher,
             mode: mode,
             selectedTransactionType: selectedTransactionType,
             selectedCategory: selectedCategory
         )
     }
-    
+
     // MARK: - Test Methods - Initialization
-    
+
     func test_initialization_configurationMode_createMode_setsCorrectInitialValues() {
         // When
         viewModel = createViewModel(mode: .configuration, selectedTransactionType: .variableExpense)
-        
+
         // Then
         XCTAssertEqual(viewModel.mode, .configuration)
         XCTAssertEqual(viewModel.selectedTransactionType, .variableExpense)
@@ -82,7 +86,7 @@ final class CategoryFormViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.alertErrorMessage)
         XCTAssertFalse(viewModel.isChanged)
     }
-    
+
     func test_initialization_configurationMode_updateMode_setsCorrectInitialValues() {
         // Given
         let existingCategory = CategoryDTO(
@@ -91,10 +95,10 @@ final class CategoryFormViewModelTests: XCTestCase {
             transactionType: .fixedExpense,
             subCategories: [SubCategoryDTO.mockSalary]
         )
-        
+
         // When
         viewModel = createViewModel(mode: .configuration, selectedCategory: existingCategory)
-        
+
         // Then
         XCTAssertEqual(viewModel.mode, .configuration)
         XCTAssertEqual(viewModel.selectedTransactionType, .fixedExpense)
@@ -104,215 +108,102 @@ final class CategoryFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.subCategories.count, 1)
         XCTAssertEqual(viewModel.subCategories.first?.id, SubCategoryDTO.mockSalary.id)
     }
-    
+
     func test_initialization_selectionMode_setsCorrectInitialValues() {
         // When
         viewModel = createViewModel(mode: .selection, selectedTransactionType: .income)
-        
+
         // Then
         XCTAssertEqual(viewModel.mode, .selection)
         XCTAssertEqual(viewModel.selectedTransactionType, .income)
         XCTAssertNil(viewModel.selectedCategory)
     }
-    
-    // MARK: - Test Methods - Validation - Configuration Mode
-    
-    func test_isValid_configurationMode_createMode_withValidData_returnsTrue() {
-        // Given
+
+    // MARK: - Test Methods - Validation
+
+    func test_isValid_createMode_validatesCorrectly() {
         viewModel = createViewModel(mode: .configuration)
-        viewModel.categoryName = "새 카테고리"
-        viewModel.categoryIconName = "new.icon"
-        
-        // When
-        let isValid = viewModel.isValid
-        
-        // Then
-        XCTAssertTrue(isValid)
-    }
-    
-    func test_isValid_configurationMode_createMode_withEmptyName_returnsFalse() {
-        // Given
-        viewModel = createViewModel(mode: .configuration)
+
+        // Invalid: 빈 이름
         viewModel.categoryName = ""
-        viewModel.categoryIconName = "new.icon"
-        
-        // When
-        let isValid = viewModel.isValid
-        
-        // Then
-        XCTAssertFalse(isValid)
-    }
-    
-    func test_isValid_configurationMode_createMode_withWhitespaceOnlyName_returnsFalse() {
-        // Given
-        viewModel = createViewModel(mode: .configuration)
+        viewModel.categoryIconName = "icon"
+        XCTAssertFalse(viewModel.isValid)
+
+        // Invalid: 공백만 있는 이름
         viewModel.categoryName = "   \n\t   "
-        viewModel.categoryIconName = "new.icon"
-        
-        // When
-        let isValid = viewModel.isValid
-        
-        // Then
-        XCTAssertFalse(isValid)
-    }
-    
-    func test_isValid_configurationMode_createMode_withEmptyIcon_returnsFalse() {
-        // Given
-        viewModel = createViewModel(mode: .configuration)
-        viewModel.categoryName = "새 카테고리"
+        XCTAssertFalse(viewModel.isValid)
+
+        // Invalid: 빈 아이콘
+        viewModel.categoryName = "카테고리"
         viewModel.categoryIconName = ""
-        
-        // When
-        let isValid = viewModel.isValid
-        
-        // Then
-        XCTAssertFalse(isValid)
+        XCTAssertFalse(viewModel.isValid)
+
+        // Valid: 모든 필드 입력
+        viewModel.categoryIconName = "icon"
+        XCTAssertTrue(viewModel.isValid)
     }
-    
-    func test_isValid_configurationMode_updateMode_withoutChanges_returnsFalse() {
-        // Given
-        let existingCategory = CategoryDTO(
-            name: "기존 카테고리",
-            iconName: "existing.icon",
-            transactionType: .income
-        )
+
+    func test_isValid_updateMode_validatesChanges() {
+        let existingCategory = CategoryDTO(name: "기존", iconName: "icon", transactionType: .income)
         viewModel = createViewModel(mode: .configuration, selectedCategory: existingCategory)
-        
-        // When - 변경사항 없음
-        let isValid = viewModel.isValid
-        
-        // Then
-        XCTAssertFalse(isValid)
-    }
-    
-    func test_isValid_configurationMode_updateMode_withNameChange_returnsTrue() {
-        // Given
-        let existingCategory = CategoryDTO(
-            name: "기존 카테고리",
-            iconName: "existing.icon",
-            transactionType: .income
-        )
-        viewModel = createViewModel(mode: .configuration, selectedCategory: existingCategory)
-        
-        // When - 이름 변경
-        viewModel.categoryName = "변경된 카테고리"
-        let isValid = viewModel.isValid
-        
-        // Then
-        XCTAssertTrue(isValid)
-    }
-    
-    func test_isValid_configurationMode_updateMode_withIconChange_returnsTrue() {
-        // Given
-        let existingCategory = CategoryDTO(
-            name: "기존 카테고리",
-            iconName: "existing.icon",
-            transactionType: .income
-        )
-        viewModel = createViewModel(mode: .configuration, selectedCategory: existingCategory)
-        
-        // When - 아이콘 변경
+
+        // Invalid: 변경사항 없음
+        XCTAssertFalse(viewModel.isValid)
+
+        // Valid: 이름 변경
+        viewModel.categoryName = "변경됨"
+        XCTAssertTrue(viewModel.isValid)
+
+        // Valid: 아이콘 변경
+        viewModel.categoryName = "기존"
         viewModel.categoryIconName = "new.icon"
-        let isValid = viewModel.isValid
-        
-        // Then
-        XCTAssertTrue(isValid)
-    }
-    
-    func test_isValid_configurationMode_updateMode_withTransactionTypeChange_returnsTrue() {
-        // Given
-        let existingCategory = CategoryDTO(
-            name: "기존 카테고리",
-            iconName: "existing.icon",
-            transactionType: .income
-        )
-        viewModel = createViewModel(mode: .configuration, selectedCategory: existingCategory)
-        
-        // When - 거래 유형 변경
+        XCTAssertTrue(viewModel.isValid)
+
+        // Valid: 거래 유형 변경
+        viewModel.categoryIconName = "icon"
         viewModel.selectedTransactionType = .variableExpense
-        let isValid = viewModel.isValid
-        
-        // Then
-        XCTAssertTrue(isValid)
-    }
-    
-    func test_isValid_configurationMode_updateMode_withAddedSubCategory_returnsTrue() {
-        // Given
-        let existingCategory = CategoryDTO(
-            name: "기존 카테고리",
-            iconName: "existing.icon",
-            transactionType: .income
-        )
-        viewModel = createViewModel(mode: .configuration, selectedCategory: existingCategory)
-        
-        // When - 서브카테고리 추가
+        XCTAssertTrue(viewModel.isValid)
+
+        // Valid: 서브카테고리 추가
+        viewModel.selectedTransactionType = .income
         viewModel.addedSubCategories = [SubCategoryDTO.mockSalary]
-        let isValid = viewModel.isValid
-        
-        // Then
-        XCTAssertTrue(isValid)
+        XCTAssertTrue(viewModel.isValid)
     }
-    
-    // MARK: - Test Methods - Validation - Selection Mode
-    
-    func test_isValid_selectionMode_withValidData_returnsTrue() {
-        // Given
+
+    func test_isValid_selectionMode_requiresSubCategory() {
         viewModel = createViewModel(mode: .selection)
-        viewModel.categoryName = "새 카테고리"
-        viewModel.categoryIconName = "new.icon"
-        viewModel.newSubCategoryName = "새 서브카테고리"
-        
-        // When
-        let isValid = viewModel.isValid
-        
-        // Then
-        XCTAssertTrue(isValid)
-    }
-    
-    func test_isValid_selectionMode_withEmptySubCategoryName_returnsFalse() {
-        // Given
-        viewModel = createViewModel(mode: .selection)
-        viewModel.categoryName = "새 카테고리"
-        viewModel.categoryIconName = "new.icon"
+        viewModel.categoryName = "카테고리"
+        viewModel.categoryIconName = "icon"
+
+        // Invalid: 서브카테고리 없음
         viewModel.newSubCategoryName = ""
-        
-        // When
-        let isValid = viewModel.isValid
-        
-        // Then
-        XCTAssertFalse(isValid)
-    }
-    
-    func test_isValid_selectionMode_withWhitespaceOnlySubCategoryName_returnsFalse() {
-        // Given
-        viewModel = createViewModel(mode: .selection)
-        viewModel.categoryName = "새 카테고리"
-        viewModel.categoryIconName = "new.icon"
+        XCTAssertFalse(viewModel.isValid)
+
+        // Invalid: 공백만
         viewModel.newSubCategoryName = "   \t\n   "
-        
-        // When
-        let isValid = viewModel.isValid
-        
-        // Then
-        XCTAssertFalse(isValid)
+        XCTAssertFalse(viewModel.isValid)
+
+        // Valid: 서브카테고리 입력
+        viewModel.newSubCategoryName = "서브카테고리"
+        XCTAssertTrue(viewModel.isValid)
     }
-    
+
     // MARK: - Test Methods - Action Handling - showAddSubCategoryAlert
-    
+
     func test_showAddSubCategoryAlert_setsShowingAddSubCategoryAlertToTrue() {
         // Given
         viewModel = createViewModel(mode: .configuration)
         XCTAssertFalse(viewModel.showingAddSubCategoryAlert)
-        
+
         // When
         viewModel.send(.showAddSubCategoryAlert)
-        
+
         // Then
         XCTAssertTrue(viewModel.showingAddSubCategoryAlert)
     }
-    
+
     // MARK: - Test Methods - Action Handling - addSubCategory
-    
+
     func test_addSubCategory_withValidName_addsSubCategory() {
         // Given
         viewModel = createViewModel(mode: .configuration)
@@ -320,10 +211,10 @@ final class CategoryFormViewModelTests: XCTestCase {
         viewModel.categoryIconName = "test.icon"
         viewModel.selectedTransactionType = .variableExpense
         viewModel.newSubCategoryName = "새 서브카테고리"
-        
+
         // When
         viewModel.send(.addSubCategory)
-        
+
         // Then
         XCTAssertEqual(viewModel.addedSubCategories.count, 1)
         XCTAssertEqual(viewModel.addedSubCategories.first?.name, "새 서브카테고리")
@@ -333,146 +224,141 @@ final class CategoryFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.newSubCategoryName, "") // 입력 필드 초기화
         XCTAssertFalse(viewModel.showingAddSubCategoryAlert) // Alert 닫힘
     }
-    
-    func test_addSubCategory_withEmptyName_setsErrorMessage() {
-        // Given
-        viewModel = createViewModel(mode: .configuration)
-        viewModel.newSubCategoryName = ""
-        
-        // When
-        viewModel.send(.addSubCategory)
 
-        // Then
-        XCTAssertTrue(viewModel.addedSubCategories.isEmpty)
-        XCTAssertNotNil(viewModel.alertErrorMessage)
-    }
-    
-    func test_addSubCategory_withWhitespaceOnlyName_setsErrorMessage() {
-        // Given
+    func test_addSubCategory_validation() {
         viewModel = createViewModel(mode: .configuration)
+
+        // Invalid: 빈 이름
+        viewModel.newSubCategoryName = ""
+        viewModel.send(.addSubCategory)
+        XCTAssertTrue(viewModel.addedSubCategories.isEmpty)
+        XCTAssertNotNil(viewModel.alertErrorMessage)
+
+        // Invalid: 공백만
         viewModel.newSubCategoryName = "   \n\t   "
-        
-        // When
         viewModel.send(.addSubCategory)
-        
-        // Then
         XCTAssertTrue(viewModel.addedSubCategories.isEmpty)
-        XCTAssertNotNil(viewModel.alertErrorMessage)
-    }
-    
-    func test_addSubCategory_withDuplicateName_setsErrorMessage() {
-        // Given
-        let existingSubCategory = SubCategoryDTO(
-            name: "기존 서브카테고리",
-            transactionType: .variableExpense,
-            categoryId: UUID(),
-            categoryName: "테스트 카테고리",
-            categoryIconName: "test.icon"
-        )
+
+        // Invalid: 중복 이름
         let existingCategory = CategoryDTO(
-            name: "테스트 카테고리",
-            iconName: "test.icon",
+            name: "카테고리",
+            iconName: "icon",
             transactionType: .variableExpense,
-            subCategories: [existingSubCategory]
+            subCategories: [SubCategoryDTO(name: "기존", transactionType: .variableExpense, categoryId: UUID(), categoryName: "카테고리", categoryIconName: "icon")]
         )
-        
         viewModel = createViewModel(mode: .configuration, selectedCategory: existingCategory)
-        viewModel.newSubCategoryName = "기존 서브카테고리" // 중복된 이름
-        
-        // When
+        viewModel.newSubCategoryName = "기존"
         viewModel.send(.addSubCategory)
-        
-        // Then
         XCTAssertTrue(viewModel.addedSubCategories.isEmpty)
         XCTAssertNotNil(viewModel.alertErrorMessage)
     }
-    
+
     // MARK: - Test Methods - Action Handling - cancelAddSubCategory
-    
+
     func test_cancelAddSubCategory_resetsAlertState() {
         // Given
         viewModel = createViewModel(mode: .configuration)
         viewModel.showingAddSubCategoryAlert = true
         viewModel.newSubCategoryName = "입력된 이름"
         viewModel.alertErrorMessage = "에러 메시지"
-        
+
         // When
         viewModel.send(.cancelAddSubCategory)
-        
+
         // Then
         XCTAssertFalse(viewModel.showingAddSubCategoryAlert)
         XCTAssertEqual(viewModel.newSubCategoryName, "")
         XCTAssertNil(viewModel.alertErrorMessage)
     }
-    
+
     // MARK: - Test Methods - Data Integrity
-    
+
     func test_addedSubCategories_maintainCorrectCategoryReference() {
         // Given
         viewModel = createViewModel(mode: .configuration)
         viewModel.categoryName = "부모 카테고리"
         viewModel.categoryIconName = "parent.icon"
         viewModel.selectedTransactionType = .income
-        
+
         // When
         viewModel.newSubCategoryName = "첫번째 서브카테고리"
         viewModel.send(.addSubCategory)
-        
+
         viewModel.newSubCategoryName = "두번째 서브카테고리"
         viewModel.send(.addSubCategory)
-        
+
         // Then
         XCTAssertEqual(viewModel.addedSubCategories.count, 2)
-        
+
         for subCategory in viewModel.addedSubCategories {
             XCTAssertEqual(subCategory.categoryName, "부모 카테고리")
             XCTAssertEqual(subCategory.categoryIconName, "parent.icon")
             XCTAssertEqual(subCategory.transactionType, .income)
         }
-        
+
         XCTAssertEqual(viewModel.addedSubCategories[0].name, "첫번째 서브카테고리")
         XCTAssertEqual(viewModel.addedSubCategories[1].name, "두번째 서브카테고리")
     }
-    
-    // MARK: - Test Methods - Different Transaction Types
-    
-    func test_validation_withDifferentTransactionTypes_worksCorrectly() {
-        // Test Income
+
+    // MARK: - Test Methods - Transaction Type Handling
+
+    func test_transactionType_propagatesToSubCategories() {
+        // Income
         viewModel = createViewModel(mode: .configuration, selectedTransactionType: .income)
-        viewModel.categoryName = "수입 카테고리"
-        viewModel.categoryIconName = "income.icon"
-        XCTAssertTrue(viewModel.isValid)
-        
-        // Test Fixed Expense
-        viewModel = createViewModel(mode: .configuration, selectedTransactionType: .fixedExpense)
-        viewModel.categoryName = "고정비 카테고리"
-        viewModel.categoryIconName = "fixed.icon"
-        XCTAssertTrue(viewModel.isValid)
-        
-        // Test Variable Expense
-        viewModel = createViewModel(mode: .configuration, selectedTransactionType: .variableExpense)
-        viewModel.categoryName = "변동비 카테고리"
-        viewModel.categoryIconName = "variable.icon"
-        XCTAssertTrue(viewModel.isValid)
-    }
-    
-    func test_addSubCategory_withDifferentTransactionTypes_setsCorrectTransactionType() {
-        // Test Income
-        viewModel = createViewModel(mode: .configuration, selectedTransactionType: .income)
-        viewModel.categoryName = "수입 카테고리"
-        viewModel.categoryIconName = "income.icon"
-        viewModel.newSubCategoryName = "수입 서브카테고리"
+        viewModel.categoryName = "카테고리"
+        viewModel.categoryIconName = "icon"
+        viewModel.newSubCategoryName = "서브카테고리"
         viewModel.send(.addSubCategory)
-        
         XCTAssertEqual(viewModel.addedSubCategories.first?.transactionType, .income)
-        
-        // Test Variable Expense
+
+        // Variable Expense
         viewModel = createViewModel(mode: .configuration, selectedTransactionType: .variableExpense)
-        viewModel.categoryName = "변동비 카테고리"
-        viewModel.categoryIconName = "variable.icon"
-        viewModel.newSubCategoryName = "변동비 서브카테고리"
+        viewModel.categoryName = "카테고리"
+        viewModel.categoryIconName = "icon"
+        viewModel.newSubCategoryName = "서브카테고리"
         viewModel.send(.addSubCategory)
-        
         XCTAssertEqual(viewModel.addedSubCategories.first?.transactionType, .variableExpense)
+    }
+
+    // MARK: - Test Methods - Delete Category
+
+    func test_deleteCategory_callsDeleteUseCaseWithCorrectId() async {
+        // Given: 수정 모드로 설정된 ViewModel
+        let category = CategoryDTO.mockFood
+        viewModel = createViewModel(mode: .configuration, selectedCategory: category)
+
+        // When: 카테고리 삭제
+        viewModel.send(.deleteCategory(mockRouter))
+
+        // Then: DeleteCategoryUseCase가 올바른 ID로 호출됨
+        try? await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(mockDeleteCategoryUseCase.executeCallCount, 1)
+        XCTAssertEqual(mockDeleteCategoryUseCase.lastDeletedCategoryId, category.id)
+    }
+
+    func test_deleteCategory_publishesDeleteEvent() async {
+        // Given: 수정 모드로 설정된 ViewModel
+        let category = CategoryDTO.mockFood
+        viewModel = createViewModel(mode: .configuration, selectedCategory: category)
+
+        // When: 카테고리 삭제
+        viewModel.send(.deleteCategory(mockRouter))
+
+        // Then: 삭제 이벤트가 발행됨
+        try? await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(mockCategoryEventPublisher.publishCallCount, 1)
+        XCTAssertEqual(mockCategoryEventPublisher.lastEvent?.type, .deleted)
+        XCTAssertEqual(mockCategoryEventPublisher.lastEvent?.category.id, category.id)
+    }
+
+    func test_showDeleteConfirmation_setsShowingDeleteConfirmationToTrue() {
+        // Given: ViewModel 생성
+        viewModel = createViewModel()
+
+        // When: 삭제 확인 표시
+        viewModel.send(.showDeleteConfirmation)
+
+        // Then: showingDeleteConfirmation이 true로 설정됨
+        XCTAssertTrue(viewModel.showingDeleteConfirmation)
     }
 }

--- a/MoneyMoaTests/Presentation/Category/SubCategoryForm/SubCategoryFormViewModelTests.swift
+++ b/MoneyMoaTests/Presentation/Category/SubCategoryForm/SubCategoryFormViewModelTests.swift
@@ -19,6 +19,7 @@ final class SubCategoryFormViewModelTests: XCTestCase {
     private var viewModel: SubCategoryFormViewModel!
     private var mockCreateSubCategoryUseCase: MockCreateSubCategoryUseCase!
     private var mockUpdateSubCategoryUseCase: MockUpdateSubCategoryUseCase!
+    private var mockDeleteSubCategoryUseCase: MockDeleteSubCategoryUseCase!
     private var mockSubCategoryEventPublisher: MockSubCategoryEventPublisher!
     private var mockRouter: AppRouter!
     private var cancellables: Set<AnyCancellable>!
@@ -27,9 +28,10 @@ final class SubCategoryFormViewModelTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        
+
         mockCreateSubCategoryUseCase = MockCreateSubCategoryUseCase()
         mockUpdateSubCategoryUseCase = MockUpdateSubCategoryUseCase()
+        mockDeleteSubCategoryUseCase = MockDeleteSubCategoryUseCase()
         mockSubCategoryEventPublisher = MockSubCategoryEventPublisher()
         mockRouter = AppRouter()
         cancellables = Set<AnyCancellable>()
@@ -40,6 +42,7 @@ final class SubCategoryFormViewModelTests: XCTestCase {
         viewModel = nil
         mockCreateSubCategoryUseCase = nil
         mockUpdateSubCategoryUseCase = nil
+        mockDeleteSubCategoryUseCase = nil
         mockSubCategoryEventPublisher = nil
         mockRouter = nil
         cancellables?.removeAll()
@@ -56,6 +59,7 @@ final class SubCategoryFormViewModelTests: XCTestCase {
         return SubCategoryFormViewModel(
             createSubCategoryUseCase: mockCreateSubCategoryUseCase,
             updateSubCategoryUseCase: mockUpdateSubCategoryUseCase,
+            deleteSubCategoryUseCase: mockDeleteSubCategoryUseCase,
             subCategoryEventPublisher: mockSubCategoryEventPublisher,
             selectedCategory: selectedCategory,
             selectedSubCategory: selectedSubCategory
@@ -429,6 +433,48 @@ final class SubCategoryFormViewModelTests: XCTestCase {
         XCTAssertEqual(updatedSubCategory?.categoryName, newCategory.name)
         XCTAssertEqual(updatedSubCategory?.categoryIconName, newCategory.iconName)
         XCTAssertEqual(updatedSubCategory?.transactionType, newCategory.transactionType)
+    }
+
+    // MARK: - Test Methods - Delete SubCategory
+
+    func test_deleteSubCategory_callsDeleteUseCaseWithCorrectId() async {
+        // Given: 수정 모드로 설정된 ViewModel
+        let subCategory = SubCategoryDTO.mockFoodExpense
+        viewModel = createViewModel(selectedSubCategory: subCategory)
+
+        // When: 서브카테고리 삭제
+        viewModel.send(.deleteSubCategory(mockRouter))
+
+        // Then: DeleteSubCategoryUseCase가 올바른 ID로 호출됨
+        try? await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(mockDeleteSubCategoryUseCase.executeCallCount, 1)
+        XCTAssertEqual(mockDeleteSubCategoryUseCase.lastDeletedSubCategoryId, subCategory.id)
+    }
+
+    func test_deleteSubCategory_publishesDeleteEvent() async {
+        // Given: 수정 모드로 설정된 ViewModel
+        let subCategory = SubCategoryDTO.mockFoodExpense
+        viewModel = createViewModel(selectedSubCategory: subCategory)
+
+        // When: 서브카테고리 삭제
+        viewModel.send(.deleteSubCategory(mockRouter))
+
+        // Then: 삭제 이벤트가 발행됨
+        try? await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(mockSubCategoryEventPublisher.publishCallCount, 1)
+        XCTAssertEqual(mockSubCategoryEventPublisher.lastPublishedSubCategoryEvent?.type, .deleted)
+        XCTAssertEqual(mockSubCategoryEventPublisher.lastPublishedSubCategoryEvent?.subCategory.id, subCategory.id)
+    }
+
+    func test_showDeleteConfirmation_setsShowingDeleteConfirmationToTrue() {
+        // Given: ViewModel 생성
+        viewModel = createViewModel()
+
+        // When: 삭제 확인 표시
+        viewModel.send(.showDeleteConfirmation)
+
+        // Then: showingDeleteConfirmation이 true로 설정됨
+        XCTAssertTrue(viewModel.showingDeleteConfirmation)
     }
 }
 

--- a/MoneyMoaTests/TestHelpers/MockClasses.swift
+++ b/MoneyMoaTests/TestHelpers/MockClasses.swift
@@ -31,11 +31,16 @@ class MockUpdateSubCategoryUseCase: UpdateSubCategoryUseCase {
 class MockCategoryEventPublisher: CategoryEventPublisher {
     private let subject = PassthroughSubject<CategoryEvent, Never>()
 
+    var publishCallCount = 0
+    var lastEvent: CategoryEvent?
+
     var categoryEvents: AnyPublisher<CategoryEvent, Never> {
         subject.eraseToAnyPublisher()
     }
 
     func publish(_ event: CategoryEvent) {
+        publishCallCount += 1
+        lastEvent = event
         subject.send(event)
     }
 }
@@ -80,6 +85,40 @@ class MockUpdateCategoryUseCase: UpdateCategoryUseCase {
     func execute(_ category: CategoryDTO) async throws {
         executeCallCount += 1
         lastCategory = category
+
+        if let error = executeError {
+            throw error
+        }
+    }
+}
+
+// MARK: - Mock DeleteCategoryUseCase
+
+class MockDeleteCategoryUseCase: DeleteCategoryUseCase {
+    var executeCallCount = 0
+    var lastDeletedCategoryId: UUID?
+    var executeError: Error?
+
+    func execute(_ id: UUID) async throws {
+        executeCallCount += 1
+        lastDeletedCategoryId = id
+
+        if let error = executeError {
+            throw error
+        }
+    }
+}
+
+// MARK: - Mock DeleteSubCategoryUseCase
+
+class MockDeleteSubCategoryUseCase: DeleteSubCategoryUseCase {
+    var executeCallCount = 0
+    var lastDeletedSubCategoryId: UUID?
+    var executeError: Error?
+
+    func execute(_ id: UUID) async throws {
+        executeCallCount += 1
+        lastDeletedSubCategoryId = id
 
         if let error = executeError {
             throw error


### PR DESCRIPTION
  📝 Summary

  Category와 SubCategory 삭제 기능을 구현했습니다. Transaction이 있는 경우 soft delete(isActive=false), 없는 경우 hard delete(물리적 삭제)를 수행합니다.

  🎯 작업 내용

  1️ ⃣ Data Layer

  - CategoryRepository 삭제 기능 추가
    - deleteCategory(): Category 삭제 시 연결된 SubCategory도 함께 처리
    - deleteSubCategory(): SubCategory 삭제
    - Transaction 존재 여부에 따라 soft/hard delete 자동 분기
    - fetch 시 description에 isActive 항목 추가
  - SwiftData 모델 수정
    - SubCategory.category를 optional로 변경
    - 6개 파일에서 optional category 처리 적용
    - [SubCategory].toDtos 시 isActivve만 반환
  - Repository 테스트 추가 (7개)
    - Transaction 없을 때 hard delete 검증
    - Transaction 있을 때 soft delete 검증
    - SubCategory 연쇄 삭제 검증
    - 에러 케이스 검증

  2️ ⃣ Domain Layer

  - UseCase 구현
    - DeleteCategoryUseCase: Category 삭제
    - DeleteSubCategoryUseCase: SubCategory 삭제
    - Repository 호출 및 에러 전파
  - UseCase 테스트 추가 (각 2개)
    - Repository 호출 검증
    - 에러 전파 검증

  3️ ⃣ Presentation Layer

  - CategoryFormView/ViewModel
    - 수정 모드에서 왼쪽 상단에 "삭제" 버튼 추가
    - 삭제 확인 Alert 구현
    - DeleteCategoryUseCase 호출 및 삭제 이벤트 발행
  - SubCategoryFormView/ViewModel
    - 수정 모드에서 "취소" 버튼을 "삭제" 버튼으로 변경
    - 삭제 확인 Alert 구현
    - DeleteSubCategoryUseCase 호출 및 삭제 이벤트 발행
  - DI Container 설정
    - AppDIContainer, MockDIContainer에 DeleteUseCase 팩토리 메서드 추가
    - ViewModel 생성 시 DeleteUseCase 주입
  - ViewModel 테스트 추가 (각 3개)
    - UseCase 호출 검증
    - 이벤트 발행 검증
    - Alert 상태 관리 검증
  - 테스트 코드 최적화
    - CategoryFormViewModelTests: 중복 테스트 통합 (524줄 → 364줄, 30% 감소)
    - 동일한 검증 로직을 하나의 테스트로 통합하여 가독성 향상

  ✅ Test Plan

  - Repository 테스트 (7개): hard delete, soft delete, 연쇄 삭제 검증
  - UseCase 테스트 (4개): Repository 호출 및 에러 전파 검증
  - ViewModel 테스트 (6개): UI 상태 관리 및 UseCase 호출 검증
  - 수동 테스트: UI에서 삭제 버튼 동작 확인

  🔍 주요 기술 결정

  SwiftData Relationship 처리

  - 문제: Category 삭제 시 "Cannot remove Category from relationship" 에러 발생
  - 원인: .cascade deleteRule과 non-optional relationship의 충돌
  - 해결: SubCategory.category를 optional로 변경

  Soft/Hard Delete 자동 분기

  - Transaction이 있으면 isActive=false (데이터 보존)
  - Transaction이 없으면 물리적 삭제 (불필요한 데이터 제거)
  - Repository 레벨에서 자동 처리하여 UseCase는 단순하게 유지

  삭제 확인 UX

  - 삭제 버튼 클릭 → Alert로 확인 → 삭제 실행
  - Category 삭제 시 "연결된 모든 서브카테고리도 함께 삭제됩니다" 안내
